### PR TITLE
update to make timers reported as counters

### DIFF
--- a/metrics/transport/signalfx.go
+++ b/metrics/transport/signalfx.go
@@ -55,10 +55,10 @@ func (t *SFXTransport) Publish(m *metrics.RawMetric) error {
 	switch m.Type {
 	case metrics.GaugeType:
 		p.MetricType = datapoint.Gauge
-	case metrics.TimerType:
-		fallthrough
 	case metrics.CumulativeType:
 		p.MetricType = datapoint.Counter
+	case metrics.TimerType:
+		fallthrough
 	case metrics.CounterType:
 		p.MetricType = datapoint.Count
 	}


### PR DESCRIPTION
We were reporting timers as cumulative counters. This gives them a natural rollup of rate/sec..which doesn't necessarily make sense.