### PR TITLE
create the graceful server package

### DIFF
--- a/graceful/graceful.go
+++ b/graceful/graceful.go
@@ -1,0 +1,86 @@
+package graceful
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+var DefaultShutdownTimeout = time.Second * 60
+
+type GracefulServer struct {
+	server   *http.Server
+	listener net.Listener
+	log      *logrus.Entry
+
+	URL             string
+	ShutdownTimeout time.Duration
+}
+
+func NewGracefulServer(handler http.Handler, log *logrus.Entry) *GracefulServer {
+	return &GracefulServer{
+		server:          &http.Server{Handler: handler},
+		log:             log,
+		listener:        nil,
+		ShutdownTimeout: DefaultShutdownTimeout,
+	}
+}
+
+func (svr *GracefulServer) Bind(addr string) error {
+	l, err := net.Listen("tcp", addr)
+	if err != nil {
+		return err
+	}
+	svr.URL = "http://" + l.Addr().String()
+	svr.listener = l
+	return nil
+}
+
+func (svr *GracefulServer) Listen() error {
+	go svr.listenForShutdownSignal()
+	return svr.server.Serve(svr.listener)
+}
+
+func (svr *GracefulServer) listenForShutdownSignal() {
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM, syscall.SIGINT)
+	sig := <-c
+	svr.log.Infof("Triggering shutdown from signal %s", sig)
+
+	shutErr := svr.Close()
+	if shutErr == context.DeadlineExceeded {
+		svr.log.WithError(shutErr).Warnf("Forcing a shutdown after waiting %s", svr.ShutdownTimeout.String())
+		shutErr = svr.server.Close()
+	}
+
+	if shutErr != nil {
+		svr.log.WithError(shutErr).Warnf("Error while shutting down")
+	}
+
+}
+
+func (svr *GracefulServer) ListenAndServe(addr string) error {
+	if svr.listener != nil {
+		return errors.New("The listener has already started, don't call Bind first")
+	}
+	if err := svr.Bind(addr); err != nil {
+		return err
+	}
+
+	return svr.Listen()
+}
+
+func (svr *GracefulServer) Close() error {
+	ctx, cancel := context.WithTimeout(context.Background(), svr.ShutdownTimeout)
+	defer cancel()
+
+	svr.log.Infof("Triggering shutdown, in at most %s ", svr.ShutdownTimeout.String())
+	return svr.server.Shutdown(ctx)
+}

--- a/graceful/graceful_test.go
+++ b/graceful/graceful_test.go
@@ -42,7 +42,7 @@ func TestStartAndStop(t *testing.T) {
 	require.NoError(t, svr.Bind("127.0.0.1:0"))
 
 	go func() {
-		assert.True(t, http.ErrServerClosed == svr.Listen())
+		assert.NoError(t, svr.Listen())
 		close(finishedListening)
 	}()
 
@@ -58,7 +58,7 @@ func TestStartAndStop(t *testing.T) {
 
 	// initate a shutdown
 	go func() {
-		svr.Close()
+		assert.NoError(t, svr.Shutdown())
 		close(stoppedServer)
 	}()
 

--- a/graceful/graceful_test.go
+++ b/graceful/graceful_test.go
@@ -1,0 +1,85 @@
+package graceful
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStartAndStop(t *testing.T) {
+	orTimeout := func(c chan bool, i int, msg string) {
+		select {
+		case <-c:
+		case <-time.After(time.Duration(i) * time.Second):
+			assert.FailNow(t, msg)
+		}
+	}
+
+	gotRequest := make(chan bool)
+	clearRequest := make(chan bool)
+	stoppedServer := make(chan bool)
+	finishedListening := make(chan bool)
+
+	var finished bool
+
+	oh := func(w http.ResponseWriter, r *http.Request) {
+		// trigger that we got the request
+		close(gotRequest)
+		// wait for a clear on that request
+		orTimeout(clearRequest, 2, "waiting for request to be cleared")
+		finished = true
+	}
+
+	svr := NewGracefulServer(http.HandlerFunc(oh), logrus.WithField("testing", true))
+	require.NoError(t, svr.Bind("127.0.0.1:0"))
+
+	go func() {
+		assert.True(t, http.ErrServerClosed == svr.Listen())
+		close(finishedListening)
+	}()
+
+	// make a request
+	go func() {
+		rsp, err := http.Get(svr.URL + "/something")
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, rsp.StatusCode)
+	}()
+
+	// wait for the origin to get the request
+	orTimeout(gotRequest, 1, "didn't get the original request in time")
+
+	// initate a shutdown
+	go func() {
+		svr.Close()
+		close(stoppedServer)
+	}()
+
+	<-time.After(time.Second)
+
+	// make a second request ~ should be bounced
+	rsp, err := http.Get(svr.URL + "/something")
+	switch e := err.(type) {
+	case *url.Error:
+		assert.True(t, strings.Contains(e.Error(), "connection refused"))
+	default:
+		assert.Fail(t, fmt.Sprintf("unknown type: %v", reflect.TypeOf(err)))
+	}
+	assert.Nil(t, rsp)
+
+	// finish the first request
+	close(clearRequest)
+
+	// wait for server to close
+	orTimeout(stoppedServer, 1, "didn't stop server in time")
+
+	assert.True(t, finished)
+	orTimeout(finishedListening, 1, "didn't actually stop the server in time")
+}


### PR DESCRIPTION
This is derived heavily from https://github.com/netlify/gocommerce/pull/65/files

It is intentionally split out into Bind and Listen methods (with a ListenAndServe) so that testing is easier. It also intentionally uses the listener directly because it supports using 0 as a port and letting the system decide the port.