### PR TITLE
support for optional TLS in rabbit and nats

### DIFF
--- a/messaging/nats.go
+++ b/messaging/nats.go
@@ -3,8 +3,8 @@ package messaging
 import (
 	"strings"
 
-	"github.com/sirupsen/logrus"
 	"github.com/nats-io/nats"
+	"github.com/sirupsen/logrus"
 
 	"github.com/rybit/nats_logrus_hook"
 
@@ -70,7 +70,9 @@ func ConnectToNats(config *NatsConfig, errHandler nats.ErrHandler) (*nats.Conn, 
 		if err != nil {
 			return nil, err
 		}
-		options = append(options, nats.Secure(tlsConfig))
+		if tlsConfig != nil {
+			options = append(options, nats.Secure(tlsConfig))
+		}
 	}
 
 	if errHandler != nil {


### PR DESCRIPTION
The TLS configuration can be nil, meaning we don't want TLS. We need to respect that. Also adds some debugging messages to the rabbitMQ connection code and the envconfig tags