### PR TITLE
handle missing .env files

### DIFF
--- a/nconf/env.go
+++ b/nconf/env.go
@@ -1,6 +1,8 @@
 package nconf
 
 import (
+	"os"
+
 	"github.com/joho/godotenv"
 	"github.com/kelseyhightower/envconfig"
 )
@@ -9,9 +11,13 @@ func LoadFromEnv(prefix, filename string, face interface{}) error {
 	var err error
 	if filename == "" {
 		err = godotenv.Load()
+		if os.IsNotExist(err) {
+			err = nil
+		}
 	} else {
 		err = godotenv.Load(filename)
 	}
+
 	if err != nil {
 		return err
 	}

--- a/nconf/env_test.go
+++ b/nconf/env_test.go
@@ -1,0 +1,59 @@
+package nconf
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnvLoadingNoFile(t *testing.T) {
+	os.Clearenv()
+
+	os.Setenv("TEST_VILLIAN", "joker")
+	os.Setenv("TEST_HERO", "batman")
+
+	out := struct {
+		Villian string
+		Hero    string
+	}{}
+
+	assert.NoError(t, LoadFromEnv("test", "", &out))
+
+	assert.Equal(t, "batman", out.Hero)
+	assert.Equal(t, "joker", out.Villian)
+}
+
+func TestEnvLoadingMissingFile(t *testing.T) {
+	os.Clearenv()
+	out := struct {
+		Villian string
+		Hero    string
+	}{}
+
+	err := LoadFromEnv("test", "should-exist.env", &out)
+	assert.Error(t, err)
+}
+
+func TestEnvLoadingFromFile(t *testing.T) {
+	os.Clearenv()
+
+	f, err := ioutil.TempFile("", "env-testing")
+	require.NoError(t, err)
+	defer os.Remove(f.Name())
+
+	data := "TEST_VILLIAN=joker\nTEST_HERO=batman\n"
+	ioutil.WriteFile(f.Name(), []byte(data), 0644)
+
+	out := struct {
+		Villian string
+		Hero    string
+	}{}
+
+	assert.NoError(t, LoadFromEnv("test", f.Name(), &out))
+
+	assert.Equal(t, "batman", out.Hero)
+	assert.Equal(t, "joker", out.Villian)
+}


### PR DESCRIPTION
We should handle if there is no .env file. But if you specify a file we should error if it is missing.