### PR TITLE
return a not found error not custom error

### DIFF
--- a/ntoml/netlify_toml.go
+++ b/ntoml/netlify_toml.go
@@ -1,11 +1,9 @@
 package ntoml
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
-	"strings"
 
 	"github.com/BurntSushi/toml"
 	"github.com/pkg/errors"
@@ -83,7 +81,7 @@ func LoadFrom(paths ...string) (*NetlifyToml, error) {
 			return out, nil
 		}
 	}
-	return nil, fmt.Errorf("Failed to find toml file in %s", strings.Join(paths, ","))
+	return nil, os.ErrNotExist
 }
 
 func Save(conf *NetlifyToml) error {

--- a/ntoml/netlify_toml_test.go
+++ b/ntoml/netlify_toml_test.go
@@ -9,6 +9,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestMissingFile(t *testing.T) {
+	_, err := LoadFrom("does-not-exist")
+	assert.True(t, os.IsNotExist(err))
+}
+
 func TestLoadingExample(t *testing.T) {
 	tmp := testToml(t)
 	defer os.Remove(t.Name())


### PR DESCRIPTION
We were returning a custom error, that made it hard to _optionally_ specify paths for a toml file. Now we throw an error if we don't find it like before, but provide a way to check if we actually care