### PR TITLE
add an optional bugsnag hook

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 339fd13f8046318b0a0df3f78ef85db9fc7536ed1e15fb5223109515f1ed2bf0
-updated: 2017-10-03T10:49:34.76139528+02:00
+hash: c8eb62cdd2b47fd7b2e122f7cdb450721344935bfb5ba449152f9b7fd7442d59
+updated: 2017-10-05T15:41:40.462833307-04:00
 imports:
 - name: github.com/BurntSushi/toml
   version: b26d9c308763d68093482582cea63d69be07a0f0
@@ -14,10 +14,10 @@ imports:
   subpackages:
   - hcl/ast
   - hcl/parser
-  - hcl/scanner
-  - hcl/strconv
   - hcl/token
   - json/parser
+  - hcl/scanner
+  - hcl/strconv
   - json/scanner
   - json/token
 - name: github.com/inconshreveable/mousetrap
@@ -32,13 +32,11 @@ imports:
   version: 8d7837e64d3c1ee4e54a880c5a920ab4316fc90a
 - name: github.com/mitchellh/mapstructure
   version: d0303fe809921458f417bcf828397a65db30a7e4
-- name: github.com/nats-io/go-nats
-  version: 4b47946e1082797665a3da33c92860d4553455fe
+- name: github.com/nats-io/nats
+  version: 29f9728a183bf3fa7e809e14edac00b33be72088
   subpackages:
   - encoders/builtin
   - util
-- name: github.com/nats-io/nats
-  version: 29f9728a183bf3fa7e809e14edac00b33be72088
 - name: github.com/nats-io/nuid
   version: 3cf34f9fca4e88afa9da8eabd75e3326c9941b44
 - name: github.com/pelletier/go-toml
@@ -47,6 +45,8 @@ imports:
   version: 645ef00459ed84a119197bfb8d8205042c6df63d
 - name: github.com/rybit/nats_logrus_hook
   version: 8d9e8da6aeca6fe5ab668efa91d1ea0722af8d1a
+- name: github.com/shopify/logrus-bugsnag
+  version: 6dbc35f2c30d1e37549f9673dd07912452ab28a5
 - name: github.com/signalfx/com_signalfx_metrics_protobuf
   version: 93e507b42f43f458a109ca278d1542a26a0b87fc
 - name: github.com/signalfx/gohistogram
@@ -54,13 +54,13 @@ imports:
 - name: github.com/signalfx/golib
   version: cb7680940d605b817db79790c241eed2a00fa6e6
   subpackages:
+  - sfxclient
   - datapoint
   - errors
   - event
-  - eventcounter
   - log
-  - sfxclient
   - timekeeper
+  - eventcounter
 - name: github.com/sirupsen/logrus
   version: a3f95b5c423586578a4e099b11a46c2479628cac
 - name: github.com/spf13/afero
@@ -84,7 +84,7 @@ imports:
   subpackages:
   - context
 - name: golang.org/x/sys
-  version: f7928cfef4d09d1b080aa2b6fd3ca9ba1567c733
+  version: 062cd7e4e68206d8bab9b18396626e855c992658
   subpackages:
   - unix
 - name: golang.org/x/text
@@ -98,9 +98,9 @@ imports:
   version: 3f83fa5005286a7fe593b055f0d7771a7dce4655
   subpackages:
   - bson
-  - internal/json
   - internal/sasl
   - internal/scram
+  - internal/json
 - name: gopkg.in/stack.v1
   version: 817915b46b97fd7bb80e8ab6b69f01a53ac3eebf
 - name: gopkg.in/yaml.v2
@@ -113,12 +113,12 @@ testImports:
 - name: github.com/nats-io/gnatsd
   version: 5dcad241bcd7fff3aac6e9f8b47350f071f5fd38
   subpackages:
+  - test
   - auth
+  - server
   - conf
   - logger
-  - server
   - server/pse
-  - test
   - util
 - name: github.com/pmezard/go-difflib
   version: d8ed2627bdf02c080bf22230dbb337003b7aba2d

--- a/glide.lock
+++ b/glide.lock
@@ -1,6 +1,12 @@
-hash: c8eb62cdd2b47fd7b2e122f7cdb450721344935bfb5ba449152f9b7fd7442d59
-updated: 2017-10-05T15:41:40.462833307-04:00
+hash: e5b6ff6faa8f39dbd73afe227165d52f29435a36201a90aa8f21c70ae5c8d0c9
+updated: 2017-10-06T16:46:49.087941528-04:00
 imports:
+- name: github.com/bugsnag/bugsnag-go
+  version: 036f1af2a63f8133e596d1c127c86100b4642ba1
+  subpackages:
+  - errors
+- name: github.com/bugsnag/panicwrap
+  version: dd8df9a3778aaebc569794383e5c4ce87d6fd89e
 - name: github.com/BurntSushi/toml
   version: b26d9c308763d68093482582cea63d69be07a0f0
 - name: github.com/fsnotify/fsnotify
@@ -23,7 +29,9 @@ imports:
 - name: github.com/inconshreveable/mousetrap
   version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 - name: github.com/joho/godotenv
-  version: 726cc8b906e3d31c70a9671c90a13716a8d3f50d
+  version: a79fa1e548e2c689c241d10173efd51e5d689d5b
+- name: github.com/kardianos/osext
+  version: ae77be60afb1dcacde03767a8c37337fad28ac14
 - name: github.com/kelseyhightower/envconfig
   version: f611eb38b3875cc3bd991ca91c51d06446afa14c
 - name: github.com/kr/logfmt
@@ -32,11 +40,13 @@ imports:
   version: 8d7837e64d3c1ee4e54a880c5a920ab4316fc90a
 - name: github.com/mitchellh/mapstructure
   version: d0303fe809921458f417bcf828397a65db30a7e4
-- name: github.com/nats-io/nats
-  version: 29f9728a183bf3fa7e809e14edac00b33be72088
+- name: github.com/nats-io/go-nats
+  version: 4b47946e1082797665a3da33c92860d4553455fe
   subpackages:
   - encoders/builtin
   - util
+- name: github.com/nats-io/nats
+  version: 29f9728a183bf3fa7e809e14edac00b33be72088
 - name: github.com/nats-io/nuid
   version: 3cf34f9fca4e88afa9da8eabd75e3326c9941b44
 - name: github.com/pelletier/go-toml
@@ -54,15 +64,15 @@ imports:
 - name: github.com/signalfx/golib
   version: cb7680940d605b817db79790c241eed2a00fa6e6
   subpackages:
-  - sfxclient
   - datapoint
+  - sfxclient
   - errors
   - event
   - log
   - timekeeper
   - eventcounter
 - name: github.com/sirupsen/logrus
-  version: a3f95b5c423586578a4e099b11a46c2479628cac
+  version: f006c2ac4710855cf0f916dd6b77acf6b048dc6e
 - name: github.com/spf13/afero
   version: ee1bd8ee15a1306d1f9201acc41ef39cd9f99a1b
   subpackages:
@@ -79,14 +89,26 @@ imports:
   version: 25b30aa063fc18e48662b86996252eabdcf2f0c7
 - name: github.com/streadway/amqp
   version: 2cbfe40c9341ad63ba23e53013b3ddc7989d801c
+- name: golang.org/x/crypto
+  version: 9477e0b78b9ac3d0b03822fd95422e2fe07627cd
+  subpackages:
+  - ssh/terminal
+  - bcrypt
+  - blowfish
 - name: golang.org/x/net
   version: 8351a756f30f1297fe94bbf4b767ec589c6ea6d0
   subpackages:
   - context
 - name: golang.org/x/sys
-  version: 062cd7e4e68206d8bab9b18396626e855c992658
+  version: f7928cfef4d09d1b080aa2b6fd3ca9ba1567c733
   subpackages:
   - unix
+  - windows/svc
+  - windows/svc/debug
+  - windows/svc/mgr
+  - windows/svc/eventlog
+  - windows
+  - windows/registry
 - name: golang.org/x/text
   version: 1cbadb444a806fd9430d14ad08967ed91da4fa0a
   subpackages:
@@ -111,10 +133,9 @@ testImports:
   subpackages:
   - spew
 - name: github.com/nats-io/gnatsd
-  version: 5dcad241bcd7fff3aac6e9f8b47350f071f5fd38
+  version: 12a5ced612f30aa511906c0de12a124233752f70
   subpackages:
   - test
-  - auth
   - server
   - conf
   - logger
@@ -129,9 +150,3 @@ testImports:
   subpackages:
   - assert
   - require
-- name: golang.org/x/crypto
-  version: 9477e0b78b9ac3d0b03822fd95422e2fe07627cd
-  repo: https://go.googlesource.com/crypto
-  subpackages:
-  - bcrypt
-  - blowfish

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,9 +1,11 @@
 package: github.com/netlify/netlify-commons
 import:
-- package: github.com/sirupsen/logrus
-  version: 1.0.2
+- package: github.com/BurntSushi/toml
+  version: v0.3.0
+- package: github.com/bugsnag/bugsnag-go
+  version: v1.3.0
 - package: github.com/joho/godotenv
-  version: v1.1
+  version: v1.2.0
 - package: github.com/kelseyhightower/envconfig
   version: v1.3.0
 - package: github.com/nats-io/nats
@@ -12,21 +14,21 @@ import:
   version: v0.8.0
 - package: github.com/rybit/nats_logrus_hook
   version: v1.0.4
+- package: github.com/shopify/logrus-bugsnag
 - package: github.com/signalfx/golib
   subpackages:
-  - sfxclient
   - datapoint
+  - sfxclient
+- package: github.com/sirupsen/logrus
+  version: v1.0.3
 - package: github.com/spf13/cobra
 - package: github.com/spf13/viper
   version: v1.0.0
 - package: github.com/streadway/amqp
 - package: gopkg.in/mgo.v2
-- package: github.com/BurntSushi/toml
-  version: v0.3.0
-- package: github.com/shopify/logrus-bugsnag
 testImport:
 - package: github.com/nats-io/gnatsd
-  version: v0.9.6
+  version: v1.0.4
   subpackages:
   - test
 - package: github.com/stretchr/testify

--- a/glide.yaml
+++ b/glide.yaml
@@ -23,6 +23,7 @@ import:
 - package: gopkg.in/mgo.v2
 - package: github.com/BurntSushi/toml
   version: v0.3.0
+- package: github.com/shopify/logrus-bugsnag
 testImport:
 - package: github.com/nats-io/gnatsd
   version: v0.9.6


### PR DESCRIPTION

take a look at this [bug report](https://app.bugsnag.com/netlify/bitballoon-production/errors/59d7e8a8a27120001878c890?filters%5Bevent.since%5D%5B%5D=1h&filters%5Berror.status%5D%5B%5D=open)

```

import (
	"errors"
	"fmt"
	"os"
	"time"

	"github.com/netlify/netlify-commons/nconf"
)

func main() {
	log, err := nconf.ConfigureLogging(&nconf.LoggingConfig{
		BugSnag: &nconf.BugSnagConfig{APIKey: os.Getenv("BUGSNAG_KEY")},
		Level:   "debug",
	})
	if err != nil {
		panic(err)
	}
	<-time.After(time.Second)
	log.WithError(errors.New("FAIL TEST")).Error("Test")
	<-time.After(time.Second)
	fmt.Println("exiting")
}
```

It looks like there is a bit of a race here ~ we _could_ add a recover block too, but that won't catch if we return/exit too fast.