### PR TITLE
create metering log

### DIFF
--- a/metering/logging.go
+++ b/metering/logging.go
@@ -11,28 +11,17 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var encoder *json.Encoder
-var meteringBuffer *bufio.Writer
-var logger *logrus.Entry
-var writelock sync.Mutex
-
 func init() {
 	initFromEnv()
 }
 
-func initFromEnv() {
-	fname := os.Getenv("METERING_FILENAME")
-	if fname != "" {
-		err := SetMeteringFile(fname)
-		if err != nil {
-			panic(errors.Wrapf(err, "Failed to open file '%s' which was specified by the env var 'METERING_FILENAME'", fname))
-		}
-	} else {
-		meteringBuffer = bufio.NewWriter(os.Stdout)
-		encoder = json.NewEncoder(meteringBuffer)
-	}
+var global *MeteringLog
+var errorLogger *logrus.Entry = logrus.WithField("component", "metering_errors")
 
-	logger = logrus.WithField("component", "metering")
+type MeteringLog struct {
+	writelock *sync.Mutex
+	encoder   *json.Encoder
+	buffer    *bufio.Writer
 }
 
 type MeteringEvent struct {
@@ -41,41 +30,83 @@ type MeteringEvent struct {
 	Timestamp int64                  `json:"timestamp"`
 }
 
-func SetMeteringLogger(log *logrus.Entry) {
-	if log != nil {
-		logger = log
+func initFromEnv() {
+	var err error
+	fname := os.Getenv("METERING_FILENAME")
+	if fname != "" {
+		global, err = NewMeteringLog(fname)
+		if err != nil {
+			panic(errors.Wrapf(err, "Failed to open file '%s' which was specified by the env var 'METERING_FILENAME'", fname))
+		}
+	} else {
+		global = DefaultMeteringLog()
 	}
 }
 
-func SetMeteringFile(filename string) error {
+func Global() *MeteringLog {
+	return global
+}
+
+func NewMeteringLog(filename string) (*MeteringLog, error) {
+	ml := &MeteringLog{
+		writelock: new(sync.Mutex),
+	}
+	err := ml.setOutputFile(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	return ml, nil
+}
+
+func DefaultMeteringLog() *MeteringLog {
+	return &MeteringLog{
+		writelock: new(sync.Mutex),
+		buffer:    bufio.NewWriter(os.Stdout),
+		encoder:   json.NewEncoder(os.Stdout),
+	}
+}
+func SetErrorLogger(log *logrus.Entry) {
+	if log != nil {
+		errorLogger = log
+	}
+}
+
+func SetMeteringFile(filename string) error { return global.setOutputFile(filename) }
+func (ml *MeteringLog) setOutputFile(filename string) error {
 	open, err := os.OpenFile(filename, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600)
 	if err != nil {
 		return err
 	}
-
-	meteringBuffer = bufio.NewWriter(open)
-	encoder = json.NewEncoder(meteringBuffer)
+	buf := bufio.NewWriter(open)
+	ml.buffer = buf
+	ml.encoder = json.NewEncoder(buf)
 	return nil
 }
 
 func Flush() {
-	writelock.Lock()
-	err := meteringBuffer.Flush()
-	if err != nil {
-		logger.WithError(err).Warn("Failed to flush metering logger")
+	if err := global.Flush(); err != nil {
+		errorLogger.WithError(err).Warn("Failed to flush buffer")
 	}
-	writelock.Unlock()
+}
+func (ml *MeteringLog) Flush() error {
+	ml.writelock.Lock()
+	defer ml.writelock.Unlock()
+	return ml.buffer.Flush()
 }
 
 func RecordEvent(event string, data map[string]interface{}) {
-	writelock.Lock()
-	err := encoder.Encode(&MeteringEvent{
+	if err := global.RecordEvent(event, data); err != nil {
+		errorLogger.WithError(err).WithField("event", event).Warn("Failed to encode message")
+	}
+}
+func (ml *MeteringLog) RecordEvent(event string, data map[string]interface{}) error {
+	ml.writelock.Lock()
+	defer ml.writelock.Unlock()
+
+	return ml.encoder.Encode(&MeteringEvent{
 		Event:     event,
 		Data:      data,
 		Timestamp: time.Now().UnixNano(),
 	})
-	if err != nil {
-		logger.WithError(err).WithField("event", event).Warn("Failed to encode message")
-	}
-	writelock.Unlock()
 }

--- a/metering/logging.go
+++ b/metering/logging.go
@@ -1,0 +1,81 @@
+package metering
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+var encoder *json.Encoder
+var meteringBuffer *bufio.Writer
+var logger *logrus.Entry
+var writelock sync.Mutex
+
+func init() {
+	initFromEnv()
+}
+
+func initFromEnv() {
+	fname := os.Getenv("METERING_FILENAME")
+	if fname != "" {
+		err := SetMeteringFile(fname)
+		if err != nil {
+			panic(errors.Wrapf(err, "Failed to open file '%s' which was specified by the env var 'METERING_FILENAME'", fname))
+		}
+	} else {
+		meteringBuffer = bufio.NewWriter(os.Stdout)
+		encoder = json.NewEncoder(meteringBuffer)
+	}
+
+	logger = logrus.WithField("component", "metering")
+}
+
+type MeteringEvent struct {
+	Event     string                 `json:"event"`
+	Data      map[string]interface{} `json:"data"`
+	Timestamp int64                  `json:"timestamp"`
+}
+
+func SetMeteringLogger(log *logrus.Entry) {
+	if log != nil {
+		logger = log
+	}
+}
+
+func SetMeteringFile(filename string) error {
+	open, err := os.OpenFile(filename, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600)
+	if err != nil {
+		return err
+	}
+
+	meteringBuffer = bufio.NewWriter(open)
+	encoder = json.NewEncoder(meteringBuffer)
+	return nil
+}
+
+func Flush() {
+	writelock.Lock()
+	err := meteringBuffer.Flush()
+	if err != nil {
+		logger.WithError(err).Warn("Failed to flush metering logger")
+	}
+	writelock.Unlock()
+}
+
+func RecordEvent(event string, data map[string]interface{}) {
+	writelock.Lock()
+	err := encoder.Encode(&MeteringEvent{
+		Event:     event,
+		Data:      data,
+		Timestamp: time.Now().UnixNano(),
+	})
+	if err != nil {
+		logger.WithError(err).WithField("event", event).Warn("Failed to encode message")
+	}
+	writelock.Unlock()
+}

--- a/metering/logging_test.go
+++ b/metering/logging_test.go
@@ -1,0 +1,99 @@
+package metering
+
+import (
+	"bufio"
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInit(t *testing.T) {
+	f, err := ioutil.TempFile("", "metering-test")
+	require.NoError(t, err)
+	defer os.Remove(f.Name())
+
+	require.NoError(t, os.Setenv("METERING_FILENAME", f.Name()))
+
+	initFromEnv()
+	assert.NotNil(t, logger)
+	assert.NotNil(t, meteringBuffer)
+	assert.NotNil(t, encoder)
+}
+
+func TestWriteDataAppendFile(t *testing.T) {
+	f, err := ioutil.TempFile("", "metering-test")
+	require.NoError(t, err)
+	defer os.Remove(f.Name())
+
+	ogcontents := []byte("this is a test\n")
+	f.Write(ogcontents)
+
+	require.NoError(t, SetMeteringFile(f.Name()))
+
+	startContents, err := ioutil.ReadFile(f.Name())
+	assert.NoError(t, err)
+	assert.Equal(t, ogcontents, startContents)
+
+	RecordEvent("someevent", map[string]interface{}{"somekey": 1})
+	Flush()
+	endContents, err := ioutil.ReadFile(f.Name())
+	require.NoError(t, err)
+	assert.Equal(t, ogcontents, endContents[0:len(ogcontents)])
+
+	jsonStr := endContents[len(ogcontents):]
+	me := new(MeteringEvent)
+	require.NoError(t, json.Unmarshal(jsonStr, me))
+	assert.Equal(t, "someevent", me.Event)
+	assert.Len(t, me.Data, 1)
+	assert.EqualValues(t, 1, me.Data["somekey"])
+	assert.WithinDuration(t, time.Now(), time.Unix(0, me.Timestamp), time.Second*5)
+}
+
+func TestWriteDataCreateFile(t *testing.T) {
+	d, err := ioutil.TempDir("", "metering-test-")
+	require.NoError(t, err)
+	defer os.RemoveAll(d)
+
+	path := filepath.Join(d, "test-file")
+	require.NoError(t, SetMeteringFile(path))
+
+	_, err = os.Open(path)
+	assert.NoError(t, err)
+}
+
+func TestConcurrentWrites(t *testing.T) {
+	f, err := ioutil.TempFile("", "metering-test")
+	require.NoError(t, err)
+	defer os.Remove(f.Name())
+
+	require.NoError(t, SetMeteringFile(f.Name()))
+	wg := new(sync.WaitGroup)
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			RecordEvent("someevent", map[string]interface{}{"somekey": i})
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+	Flush()
+
+	lines := 0
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		lines++
+		m := make(map[string]interface{})
+		if assert.NoError(t, json.Unmarshal(sc.Bytes(), &m)) {
+			assert.Equal(t, "someevent", m["event"].(string))
+		}
+	}
+
+	assert.Equal(t, 100, lines)
+}

--- a/metering/logging_test.go
+++ b/metering/logging_test.go
@@ -22,9 +22,16 @@ func TestInit(t *testing.T) {
 	require.NoError(t, os.Setenv("METERING_FILENAME", f.Name()))
 
 	initFromEnv()
-	assert.NotNil(t, logger)
-	assert.NotNil(t, meteringBuffer)
-	assert.NotNil(t, encoder)
+
+	assert.NotNil(t, global.buffer)
+	assert.NotNil(t, global.encoder)
+	assert.NotNil(t, global.writelock)
+}
+
+func TestInitNoFile(t *testing.T) {
+	require.NoError(t, os.Setenv("METERING_FILENAME", ""))
+	initFromEnv()
+	assert.NotNil(t, global)
 }
 
 func TestWriteDataAppendFile(t *testing.T) {
@@ -35,14 +42,20 @@ func TestWriteDataAppendFile(t *testing.T) {
 	ogcontents := []byte("this is a test\n")
 	f.Write(ogcontents)
 
-	require.NoError(t, SetMeteringFile(f.Name()))
+	ut, err := NewMeteringLog(f.Name())
+	require.NoError(t, err)
+
+	assert.NotNil(t, ut.buffer)
+	assert.NotNil(t, ut.encoder)
+	assert.NotNil(t, ut.writelock)
 
 	startContents, err := ioutil.ReadFile(f.Name())
 	assert.NoError(t, err)
 	assert.Equal(t, ogcontents, startContents)
 
-	RecordEvent("someevent", map[string]interface{}{"somekey": 1})
-	Flush()
+	require.NoError(t, ut.RecordEvent("someevent", map[string]interface{}{"somekey": 1}))
+	require.NoError(t, ut.Flush())
+
 	endContents, err := ioutil.ReadFile(f.Name())
 	require.NoError(t, err)
 	assert.Equal(t, ogcontents, endContents[0:len(ogcontents)])
@@ -54,6 +67,52 @@ func TestWriteDataAppendFile(t *testing.T) {
 	assert.Len(t, me.Data, 1)
 	assert.EqualValues(t, 1, me.Data["somekey"])
 	assert.WithinDuration(t, time.Now(), time.Unix(0, me.Timestamp), time.Second*5)
+}
+
+func TestSeparationOfGlobal(t *testing.T) {
+	d, err := ioutil.TempDir("", "metering-test-")
+	require.NoError(t, err)
+	defer os.RemoveAll(d)
+	f1 := filepath.Join(d, "file1")
+	f2 := filepath.Join(d, "file2")
+
+	require.NoError(t, SetMeteringFile(f1))
+	ut, err := NewMeteringLog(f2)
+	require.NoError(t, err)
+
+	RecordEvent("first", nil)
+	assert.NoError(t, Global().RecordEvent("second", nil))
+	assert.NoError(t, ut.RecordEvent("third", nil))
+
+	assert.NoError(t, global.Flush())
+	assert.NoError(t, ut.Flush())
+
+	file1, err := os.Open(f1)
+	require.NoError(t, err)
+	require.NoError(t, err)
+	s1 := bufio.NewScanner(file1)
+	count := 0
+	for s1.Scan() {
+		count++
+		read := new(MeteringEvent)
+		assert.NoError(t, json.Unmarshal(s1.Bytes(), read))
+		switch read.Event {
+		case "first", "second":
+		default:
+			assert.Fail(t, "Unexpected event in the global file", read.Event)
+		}
+	}
+	assert.Equal(t, 2, count)
+
+	file2, err := os.Open(f2)
+	s1 = bufio.NewScanner(file2)
+	for s1.Scan() {
+		count++
+		read := new(MeteringEvent)
+		assert.NoError(t, json.Unmarshal(s1.Bytes(), read))
+		assert.Equal(t, "third", read.Event)
+	}
+	assert.Equal(t, 3, count)
 }
 
 func TestWriteDataCreateFile(t *testing.T) {

--- a/metering/logging_test.go
+++ b/metering/logging_test.go
@@ -26,6 +26,20 @@ func TestInit(t *testing.T) {
 	assert.NotNil(t, global.buffer)
 	assert.NotNil(t, global.encoder)
 	assert.NotNil(t, global.writelock)
+
+	RecordEvent("testevent", nil)
+
+	require.NoError(t, global.Flush())
+
+	data, err := ioutil.ReadAll(f)
+	require.NoError(t, err)
+
+	m := new(MeteringEvent)
+	require.NoError(t, json.Unmarshal(data, m))
+
+	assert.Equal(t, "testevent", m.Event)
+	assert.Nil(t, m.Data)
+	assert.NotEqual(t, int64(0), m.Timestamp)
 }
 
 func TestInitNoFile(t *testing.T) {
@@ -42,7 +56,7 @@ func TestWriteDataAppendFile(t *testing.T) {
 	ogcontents := []byte("this is a test\n")
 	f.Write(ogcontents)
 
-	ut, err := NewMeteringLog(f.Name())
+	ut, err := NewLog(f.Name())
 	require.NoError(t, err)
 
 	assert.NotNil(t, ut.buffer)
@@ -77,7 +91,7 @@ func TestSeparationOfGlobal(t *testing.T) {
 	f2 := filepath.Join(d, "file2")
 
 	require.NoError(t, SetMeteringFile(f1))
-	ut, err := NewMeteringLog(f2)
+	ut, err := NewLog(f2)
 	require.NoError(t, err)
 
 	RecordEvent("first", nil)


### PR DESCRIPTION
This should let us have jsonl lines in a separate file to parse out what we need.

I decided to use a global style. I don't love that. But it was the best way I could think to not have to pass some logger around *everywhere* or very far down into call chains. 