### PR TITLE
Queue up metrics to report on interval instead of immediately

### DIFF
--- a/metrics/counter.go
+++ b/metrics/counter.go
@@ -1,6 +1,9 @@
 package metrics
 
-import "time"
+import (
+	"sync/atomic"
+	"time"
+)
 
 // Counter will send when an event occurs
 type Counter interface {
@@ -20,6 +23,6 @@ func (m *metric) Count(instanceDims DimMap) {
 
 //CountN will count N occurrences of an event
 func (m *metric) CountN(val int64, instanceDims DimMap) {
-	m.Value = val
-	m.send(instanceDims)
+	atomic.SwapInt64(&m.value, val)
+	m.send(instanceDims, val)
 }

--- a/metrics/cumulative_counter.go
+++ b/metrics/cumulative_counter.go
@@ -46,7 +46,7 @@ func (cc *cumulativeCounter) IncrementN(val int64, dims DimMap) {
 	}
 	sha, err := HashDims(dims)
 	if err != nil {
-		cc.env.reportError(&cc.RawMetric, errors.Wrap(err, "Failed to hash dimensions"))
+		cc.env.reportError(rawMetric(&cc.metric), errors.Wrap(err, "Failed to hash dimensions"))
 		return
 	}
 
@@ -57,7 +57,7 @@ func (cc *cumulativeCounter) IncrementN(val int64, dims DimMap) {
 		cc.mts[sha] = m
 	}
 
-	m.Value += val
+	m.value += val
 }
 
 func (cc *cumulativeCounter) series() []*metric {

--- a/metrics/env.go
+++ b/metrics/env.go
@@ -11,7 +11,7 @@ import (
 
 func NewEnvironment(trans Transport) *Environment {
 	return &Environment{
-		dimlock:    sync.Mutex{},
+		dimlock:    sync.RWMutex{},
 		globalDims: DimMap{},
 		transport:  trans,
 		reporter:   new(noopReporter),
@@ -20,7 +20,7 @@ func NewEnvironment(trans Transport) *Environment {
 
 type Environment struct {
 	globalDims DimMap
-	dimlock    sync.Mutex
+	dimlock    sync.RWMutex
 
 	Namespace    string
 	Tracer       func(m *RawMetric)
@@ -104,7 +104,7 @@ func (e *Environment) newMetric(name string, t MetricType, dims DimMap) *metric 
 			Dims: make(DimMap),
 		},
 		env:     e,
-		dimlock: &sync.Mutex{},
+		dimlock: &sync.RWMutex{},
 	}
 
 	if dims != nil {

--- a/metrics/env_test.go
+++ b/metrics/env_test.go
@@ -13,8 +13,8 @@ func TestSendMetric(t *testing.T) {
 
 	// create the metric
 	sender := env.newMetric("something", CounterType, nil)
-	sender.Value = 123
-	sender.send(nil)
+	sender.value = 123
+	sender.send(nil, sender.value)
 
 	if assert.Len(t, rec.metrics, 1) {
 		m := rec.metrics[0]
@@ -48,8 +48,8 @@ func TestSendWithTracer(t *testing.T) {
 
 	// create the metric
 	sender := env.newMetric("something", CounterType, nil)
-	sender.Value = 123
-	sender.send(nil)
+	sender.value = 123
+	sender.send(nil, sender.value)
 
 	if assert.Len(t, rec.metrics, 1) {
 		m := rec.metrics[0]
@@ -107,6 +107,11 @@ type recordingTransport struct {
 }
 
 func (t *recordingTransport) Publish(m *RawMetric) error {
+	t.metrics = append(t.metrics, m)
+	return nil
+}
+
+func (t *recordingTransport) Queue(m *RawMetric) error {
 	t.metrics = append(t.metrics, m)
 	return nil
 }

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -43,11 +43,10 @@ func (m *metric) SetTimestamp(t time.Time) {
 }
 
 // AddDimension will add this dimension with locking
-func (m *metric) AddDimension(key string, value interface{}) *metric {
+func (m *metric) AddDimension(key string, value interface{}) {
 	m.dimlock.Lock()
 	defer m.dimlock.Unlock()
 	m.Dims[key] = value
-	return m
 }
 
 func (m *metric) send(instanceDims DimMap) {

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -28,8 +28,12 @@ type RawMetric struct {
 }
 
 type metric struct {
-	RawMetric
+	Name      string     `json:"name"`
+	Type      MetricType `json:"type"`
+	Dims      DimMap     `json:"dimensions"`
+	Timestamp int64      `json:"timestamp"`
 
+	value   int64
 	dimlock *sync.RWMutex
 	env     *Environment
 }
@@ -49,10 +53,10 @@ func (m *metric) AddDimension(key string, value interface{}) {
 	m.Dims[key] = value
 }
 
-func (m *metric) send(instanceDims DimMap) {
+func (m *metric) send(instanceDims DimMap, val int64) {
 	metricToSend := &RawMetric{
 		Type:      m.Type,
-		Value:     m.Value,
+		Value:     val,
 		Name:      m.Name,
 		Timestamp: m.Timestamp,
 		Dims:      DimMap{},

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -30,7 +30,7 @@ type RawMetric struct {
 type metric struct {
 	RawMetric
 
-	dimlock *sync.Mutex
+	dimlock *sync.RWMutex
 	env     *Environment
 }
 
@@ -60,14 +60,14 @@ func (m *metric) send(instanceDims DimMap) {
 	}
 
 	// global
-	m.env.dimlock.Lock()
+	m.env.dimlock.RLock()
 	addAll(metricToSend.Dims, m.env.globalDims)
-	m.env.dimlock.Unlock()
+	m.env.dimlock.RUnlock()
 
 	// metric
-	m.dimlock.Lock()
+	m.dimlock.RLock()
 	addAll(metricToSend.Dims, m.Dims)
-	m.dimlock.Unlock()
+	m.dimlock.RUnlock()
 
 	// instance
 	addAll(metricToSend.Dims, instanceDims)

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -24,7 +24,7 @@ func TestDimensionalOverride(t *testing.T) {
 	sender.send(DimMap{
 		"instance-overide": "instance-level",
 		"instance-val":     789,
-	})
+	}, sender.value)
 
 	if assert.Len(t, rec.metrics, 1) {
 		m := rec.metrics[0]
@@ -46,10 +46,10 @@ func TestSettingTimestamp(t *testing.T) {
 	ts := time.Now()
 	m := env.newMetric("thing.one", CounterType, nil)
 	m.SetTimestamp(ts)
-	m.send(nil)
+	m.send(nil, m.value)
 
 	m.SetTimestamp(time.Time{})
-	m.send(nil)
+	m.send(nil, m.value)
 
 	if assert.Len(t, rec.metrics, 2) {
 		m := rec.metrics[0]

--- a/metrics/reporter.go
+++ b/metrics/reporter.go
@@ -91,7 +91,7 @@ func (r *intervalReporter) report() {
 
 	for _, c := range r.counters {
 		for _, m := range c.series() {
-			m.send(nil)
+			m.send(nil, m.value)
 		}
 	}
 }

--- a/metrics/timer.go
+++ b/metrics/timer.go
@@ -35,12 +35,12 @@ func (t *timer) Stop(instanceDims DimMap) time.Duration {
 	now := time.Now()
 
 	if t.startTime == nil {
-		t.env.reportError(&t.RawMetric, NotStartedError{errors.New("the timer hasn't been started yet")})
+		t.env.reportError(rawMetric(&t.metric), NotStartedError{errors.New("the timer hasn't been started yet")})
 	}
 
 	diff := now.Sub(*t.startTime)
-	t.Value = int64(diff)
-	t.send(instanceDims)
+	t.value = int64(diff)
+	t.send(instanceDims, t.value)
 	return diff
 }
 

--- a/metrics/transport.go
+++ b/metrics/transport.go
@@ -2,11 +2,16 @@ package metrics
 
 type Transport interface {
 	Publish(m *RawMetric) error
+	Queue(m *RawMetric) error
 }
 
 type NoopTransport struct{}
 
 func (NoopTransport) Publish(_ *RawMetric) error {
+	return nil
+}
+
+func (NoopTransport) Queue(_ *RawMetric) error {
 	return nil
 }
 
@@ -22,13 +27,6 @@ func (t transportWrapper) Publish(m *RawMetric) error {
 	return t.f(m)
 }
 
-func NewBroadcastTransport(ports []Transport) Transport {
-	return TransportFunc(func(m *RawMetric) error {
-		for _, p := range ports {
-			if err := p.Publish(m); err != nil {
-				return err
-			}
-		}
-		return nil
-	})
+func (t transportWrapper) Queue(m *RawMetric) error {
+	return t.f(m)
 }

--- a/metrics/transport/datadog.go
+++ b/metrics/transport/datadog.go
@@ -66,6 +66,11 @@ func NewDataDogTransportWithClient(apiKey, appKey string, client *http.Client) (
 	return trans, nil
 }
 
+func (t DataDogTransport) Queue(m *metrics.RawMetric) error {
+	// TODO support queueing
+	return t.Publish(m)
+}
+
 func (t DataDogTransport) Publish(m *metrics.RawMetric) error {
 	point := DataDogMetric{
 		Metric: m.Name,

--- a/metrics/transport/nats.go
+++ b/metrics/transport/nats.go
@@ -30,3 +30,8 @@ func (t *NatsTransport) Publish(m *metrics.RawMetric) error {
 
 	return t.conn.Publish(t.subject, data)
 }
+
+func (t *NatsTransport) Queue(m *metrics.RawMetric) error {
+	// NATS does not support queueing
+	return t.Publish(m)
+}

--- a/nconf/metrics.go
+++ b/nconf/metrics.go
@@ -24,9 +24,10 @@ type MetricsConfig struct {
 	Namespace  string            `mapstructure:"namespace"`
 	Dimensions map[string]string `mapstructure:"default_dims"`
 
+	ReportSec int `mapstructure:"report_sec" split_words:"true"`
 	// for reporting cumulative counters on an interval
-	ReportSec            int  `mapstructure:"report_sec" split_words:"true"`
-	DisableTimerCounters bool `mapstructure:"disable_timer_counters" split_words:"true"`
+	CumulativeCounterReportSec int  `mapstructure:"cc_report_sec" split_words:"true"`
+	DisableTimerCounters       bool `mapstructure:"disable_timer_counters" split_words:"true"`
 }
 
 type NatsConfig struct {
@@ -71,7 +72,7 @@ func ConfigureMetrics(mconf *MetricsConfig, log *logrus.Entry) error {
 	metrics.Namespace(mconf.Namespace)
 
 	metrics.StartReportingCumulativeCounters(
-		time.Duration(mconf.ReportSec)*time.Second,
+		time.Duration(mconf.CumulativeCounterReportSec)*time.Second,
 		log.WithField("component", "stats_report"),
 	)
 


### PR DESCRIPTION
This is currently only implemented for SFX. It also adds a separate config value for the cumulative counter reporting interval (which will actually report to SFX on the next tick of the former interval).