### PR TITLE
only use go 1.11+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,8 @@
 language: go
 
 go:
-  - 1.8.x
-  - 1.9.x
-  - 1.10.x
+  - 1.11.x
+  - 1.12.x
 
 install: make deps
 script: make test


### PR DESCRIPTION
We want to go to modules we need to then be on 1.11+