### PR TITLE
Add a SafeHttpClient method

### DIFF
--- a/http/http.go
+++ b/http/http.go
@@ -2,7 +2,6 @@ package http
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -38,23 +37,6 @@ func isPrivateIP(ip net.IP) bool {
 		}
 	}
 	return false
-}
-
-func isLocalAddress(addr string) bool {
-	ip := net.ParseIP(addr)
-	return isPrivateIP(ip)
-}
-
-// SafeDialContext exchanges a DialContext for a SafeDialContext that will never dial a reserved IP range
-func SafeDialContext(dialContext func(ctx context.Context, network, addr string) (net.Conn, error)) func(ctx context.Context, network, addr string) (net.Conn, error) {
-	return func(ctx context.Context, network, addr string) (net.Conn, error) {
-		if isLocalAddress(addr) {
-			return nil, errors.New("Connection to local network address denied")
-		}
-
-		return dialContext(ctx, network, addr)
-	}
-
 }
 
 type noLocalTransport struct {

--- a/http/http.go
+++ b/http/http.go
@@ -94,7 +94,7 @@ func isLocal(info httptrace.DNSDoneInfo) string {
 	return ""
 }
 
-func newLocalBlocker(trans http.RoundTripper, log logrus.FieldLogger) *noLocalTransport {
+func SafeRountripper(trans http.RoundTripper, log logrus.FieldLogger) http.RoundTripper {
 	if trans == nil {
 		trans = http.DefaultTransport
 	}
@@ -108,7 +108,7 @@ func newLocalBlocker(trans http.RoundTripper, log logrus.FieldLogger) *noLocalTr
 }
 
 func SafeHTTPClient(client *http.Client, log logrus.FieldLogger) *http.Client {
-	client.Transport = newLocalBlocker(client.Transport, log)
+	client.Transport = SafeRountripper(client.Transport, log)
 
 	return client
 }

--- a/http/http.go
+++ b/http/http.go
@@ -82,7 +82,7 @@ func (no noLocalTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 	return no.inner.RoundTrip(req)
 }
 
-func SafeRountripper(trans http.RoundTripper, log logrus.FieldLogger, allowedBlocks ...*net.IPNet) http.RoundTripper {
+func SafeRoundtripper(trans http.RoundTripper, log logrus.FieldLogger, allowedBlocks ...*net.IPNet) http.RoundTripper {
 	if trans == nil {
 		trans = http.DefaultTransport
 	}
@@ -97,7 +97,7 @@ func SafeRountripper(trans http.RoundTripper, log logrus.FieldLogger, allowedBlo
 }
 
 func SafeHTTPClient(client *http.Client, log logrus.FieldLogger, allowedBlocks ...*net.IPNet) *http.Client {
-	client.Transport = SafeRountripper(client.Transport, log, allowedBlocks...)
+	client.Transport = SafeRoundtripper(client.Transport, log, allowedBlocks...)
 
 	return client
 }

--- a/http/http.go
+++ b/http/http.go
@@ -48,32 +48,32 @@ func (no noLocalTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 	ctx, cancel := context.WithCancel(req.Context())
 
 	ctx = httptrace.WithClientTrace(ctx, &httptrace.ClientTrace{
-		DNSDone: func(info httptrace.DNSDoneInfo) {
-			if endpoint := isLocal(info); endpoint != "" {
+		ConnectStart: func(network, addr string) {
+			fmt.Printf("Checking network %v\n", addr)
+			host, _, err := net.SplitHostPort(addr)
+			if err != nil {
 				cancel()
-				if no.errlog != nil {
-					no.errlog.WithFields(logrus.Fields{
-						"original_url":     req.URL.String(),
-						"blocked_endpoint": endpoint,
-					})
-				}
+				fmt.Printf("Canceleing dur to error in addr parsing %v", err)
+				return
 			}
+			ip := net.ParseIP(host)
+			if ip == nil {
+				cancel()
+				fmt.Printf("Canceleing dur to error in ip parsing %v", host)
+				return
+			}
+
+			if isPrivateIP(ip) {
+				cancel()
+				fmt.Println("Canceleing dur to private ip range")
+				return
+			}
+
 		},
 	})
 
 	req = req.WithContext(ctx)
 	return no.inner.RoundTrip(req)
-}
-
-func isLocal(info httptrace.DNSDoneInfo) string {
-	fmt.Printf("Got dns info: %v\n", info)
-	for _, addr := range info.Addrs {
-		fmt.Printf("Checking addr: %v\n", addr)
-		if isPrivateIP(addr.IP) {
-			return fmt.Sprintf("%v", addr.IP)
-		}
-	}
-	return ""
 }
 
 func SafeRountripper(trans http.RoundTripper, log logrus.FieldLogger) http.RoundTripper {

--- a/http/http.go
+++ b/http/http.go
@@ -3,7 +3,10 @@ package http
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
+	"net/http"
+	"net/http/httptrace"
 )
 
 var privateIPBlocks []*net.IPNet
@@ -49,4 +52,48 @@ func SafeDialContext(dialContext func(ctx context.Context, network, addr string)
 
 		return dialContext(ctx, network, addr)
 	}
+
+}
+
+// transport is an http.RoundTripper that keeps track of the in-flight
+// request and implements hooks to report HTTP tracing events.
+type tracingTransport struct {
+	trace     *httptrace.ClientTrace
+	transport http.RoundTripper
+	req       *http.Request
+	cancel    context.CancelFunc
+}
+
+// RoundTrip wraps http.DefaultTransport.RoundTrip to keep track
+// of the current request.
+func (t *tracingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	ctx, cancel := context.WithCancel(httptrace.WithClientTrace(req.Context(), t.trace))
+	t.req = req.WithContext(ctx)
+	t.cancel = cancel
+	return t.transport.RoundTrip(t.req)
+}
+
+// GotConn prints whether the connection has been used previously
+// for the current request.
+func (t *tracingTransport) DNSDone(info httptrace.DNSDoneInfo) {
+	fmt.Printf("Got dns info: %v\n", info)
+	for _, addr := range info.Addrs {
+		fmt.Printf("Checking addr: %v\n", addr)
+		if isPrivateIP(addr.IP) {
+			fmt.Printf("Got private IP %v\n", addr.IP)
+			t.cancel()
+		}
+	}
+}
+
+func SafeHttpClient(client *http.Client) *http.Client {
+	transport := &tracingTransport{transport: client.Transport}
+	fmt.Printf("Transport in client is: %v\n", transport.transport)
+	if transport.transport == nil {
+		transport.transport = http.DefaultTransport
+	}
+	transport.trace = &httptrace.ClientTrace{DNSDone: transport.DNSDone}
+	client.Transport = transport
+
+	return client
 }

--- a/http/http.go
+++ b/http/http.go
@@ -2,7 +2,6 @@ package http
 
 import (
 	"context"
-	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptrace"
@@ -49,23 +48,22 @@ func (no noLocalTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 
 	ctx = httptrace.WithClientTrace(ctx, &httptrace.ClientTrace{
 		ConnectStart: func(network, addr string) {
-			fmt.Printf("Checking network %v\n", addr)
 			host, _, err := net.SplitHostPort(addr)
 			if err != nil {
 				cancel()
-				fmt.Printf("Canceleing dur to error in addr parsing %v", err)
+				no.errlog.WithError(err).Error("Cancelled request due to error in address parsing")
 				return
 			}
 			ip := net.ParseIP(host)
 			if ip == nil {
 				cancel()
-				fmt.Printf("Canceleing dur to error in ip parsing %v", host)
+				no.errlog.WithError(err).Error("Cancelled request due to error in ip parsing")
 				return
 			}
 
 			if isPrivateIP(ip) {
 				cancel()
-				fmt.Println("Canceleing dur to private ip range")
+				no.errlog.Error("Cancelled attempted request to ip in private range")
 				return
 			}
 

--- a/http/http_test.go
+++ b/http/http_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -44,7 +45,7 @@ func TestSafeHTTPClient(t *testing.T) {
 	assert.Equal(t, 200, res.StatusCode)
 	assert.Equal(t, 1, counter.count)
 
-	client = SafeHttpClient(client)
+	client = SafeHTTPClient(client, logrus.New())
 
 	res, err = client.Get("http://localhost:9999")
 	assert.NotNil(t, err)

--- a/http/http_test.go
+++ b/http/http_test.go
@@ -10,15 +10,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestIsLocalAddress(t *testing.T) {
-	assert.False(t, isLocalAddress("216.58.194.206"))
-	assert.True(t, isLocalAddress("127.0.0.1"))
-	assert.True(t, isLocalAddress("10.0.0.1"))
-	assert.True(t, isLocalAddress("192.168.0.1"))
-	assert.True(t, isLocalAddress("172.16.0.0"))
-	assert.True(t, isLocalAddress("169.254.169.254"))
-}
-
 type countServer struct {
 	count int
 }
@@ -48,6 +39,13 @@ func TestSafeHTTPClient(t *testing.T) {
 	client = SafeHTTPClient(client, logrus.New())
 
 	res, err = client.Get("http://localhost:9999")
+	assert.NotNil(t, err)
+	assert.Nil(t, res)
+	assert.Equal(t, 1, counter.count)
+
+	fmt.Println("Trying ip based req")
+	res, err = client.Get("http://169.254.169.254:9999")
+	fmt.Printf("Got res %v and err %v", res, err)
 	assert.NotNil(t, err)
 	assert.Nil(t, res)
 	assert.Equal(t, 1, counter.count)

--- a/http/http_test.go
+++ b/http/http_test.go
@@ -40,7 +40,7 @@ func TestSafeHTTPClient(t *testing.T) {
 
 	// It succeeds when the local IP range used by the testserver is removed from
 	// the blacklist.
-	ipNet := unshiftMatch(net.ParseIP(tsURL.Hostname()))
+	ipNet := popMatchingBlock(net.ParseIP(tsURL.Hostname()))
 	defer func() {
 		privateIPBlocks = append(privateIPBlocks, ipNet)
 	}()
@@ -49,7 +49,7 @@ func TestSafeHTTPClient(t *testing.T) {
 	assert.Nil(t, err)
 }
 
-func unshiftMatch(ip net.IP) *net.IPNet {
+func popMatchingBlock(ip net.IP) *net.IPNet {
 	for i, ipNet := range privateIPBlocks {
 		if ipNet.Contains(ip) {
 			privateIPBlocks = append(privateIPBlocks[:i], privateIPBlocks[i+1:]...)

--- a/http/http_test.go
+++ b/http/http_test.go
@@ -11,11 +11,23 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type countServer struct {
-	count int
-}
+func TestIsPrivateIP(t *testing.T) {
+	tests := []struct {
+		ip       string
+		expected bool
+	}{
+		{"216.58.194.206", false},
+		{"127.0.0.1", true},
+		{"10.0.0.1", true},
+		{"192.168.0.1", true},
+		{"172.16.0.0", true},
+		{"169.254.169.254", true},
+	}
 
-func (c *countServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	for _, tt := range tests {
+		ip := net.ParseIP(tt.ip)
+		assert.Equal(t, tt.expected, isPrivateIP(ip))
+	}
 }
 
 func TestSafeHTTPClient(t *testing.T) {


### PR DESCRIPTION
This adds a tracing method to a client that will make sure
any request to a reserved IP is canceled at DNSDone time