### PR TITLE
RootArg structure for easier config

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/spf13/afero v1.2.2 // indirect
 	github.com/spf13/cobra v0.0.4-0.20190321000552-67fc4837d267
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.3
 	github.com/spf13/viper v1.3.2
 	github.com/stretchr/testify v1.3.0
 	github.com/tinylib/msgp v1.1.0 // indirect

--- a/nconf/args.go
+++ b/nconf/args.go
@@ -1,0 +1,71 @@
+package nconf
+
+import (
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/pflag"
+)
+
+type RootArgs struct {
+	Prefix  string
+	EnvFile string
+}
+
+func (args *RootArgs) Setup(config interface{}, version string) logrus.FieldLogger {
+	// first load the logger
+	logConfig := &struct {
+		Log *LoggingConfig
+	}{}
+	if err := LoadFromEnv(args.Prefix, args.EnvFile, logConfig); err != nil {
+		logrus.WithError(err).Fatal("Failed to load the logging configuration")
+	}
+
+	log, err := ConfigureLogging(logConfig.Log)
+	if err != nil {
+		logrus.WithError(err).Fatal("Failed to create the logger")
+	}
+	if version == "" {
+		version = "unknown"
+	}
+	log = log.WithField("version", version)
+
+	if config != nil {
+		// second load the config for this project
+		if err := LoadFromEnv(args.Prefix, args.EnvFile, config); err != nil {
+			log.WithError(err).Fatal("Failed to load the config object")
+		}
+		log.Debug("Loaded configuration")
+	}
+	return log
+}
+
+func (args *RootArgs) ConfigFlag() *pflag.Flag {
+	return &pflag.Flag{
+		Name:      "config",
+		Shorthand: "c",
+		Usage:     "A .env file to load configuration from",
+		Value:     newStringValue("", &args.EnvFile),
+	}
+}
+
+func (args *RootArgs) PrefixFlag() *pflag.Flag {
+	return &pflag.Flag{
+		Name:      "prefix",
+		Shorthand: "p",
+		Usage:     "A prefix to search for when looking for env vars",
+		Value:     newStringValue("", &args.Prefix),
+	}
+}
+
+type stringValue string
+
+func newStringValue(val string, p *string) *stringValue {
+	*p = val
+	return (*stringValue)(p)
+}
+
+func (s *stringValue) Set(val string) error {
+	*s = stringValue(val)
+	return nil
+}
+func (s *stringValue) Type() string   { return "string" }
+func (s *stringValue) String() string { return string(*s) }

--- a/nconf/args_test.go
+++ b/nconf/args_test.go
@@ -1,0 +1,68 @@
+package nconf
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestArgsLoad(t *testing.T) {
+	cfg := &struct {
+		Something  string
+		Other      int
+		Overridden string
+	}{
+		Something:  "default",
+		Overridden: "this should change",
+	}
+
+	tmp, err := ioutil.TempFile("", "something")
+	require.NoError(t, err)
+	cfgStr := `
+PF_OTHER=10
+PF_OVERRIDDEN=not-that
+PF_LOG_LEVEL=debug
+PF_LOG_QUOTE_EMPTY_FIELDS=true
+`
+	require.NoError(t, ioutil.WriteFile(tmp.Name(), []byte(cfgStr), 0644))
+
+	args := RootArgs{
+		Prefix:  "pf",
+		EnvFile: tmp.Name(),
+	}
+
+	log := args.Setup(cfg, "")
+
+	// check that we did call configure the logger
+	assert.NotNil(t, log)
+	entry := log.(*logrus.Entry)
+	assert.Equal(t, logrus.DebugLevel, entry.Logger.Level)
+	assert.True(t, entry.Logger.Formatter.(*logrus.TextFormatter).QuoteEmptyFields)
+
+	assert.Equal(t, "default", cfg.Something)
+	assert.Equal(t, 10, cfg.Other)
+	assert.Equal(t, "not-that", cfg.Overridden)
+}
+
+func TestArgsAddToCmd(t *testing.T) {
+	args := new(RootArgs)
+	var called int
+	cmd := cobra.Command{
+		Run: func(_ *cobra.Command, _ []string) {
+			assert.Equal(t, "PF", args.Prefix)
+			assert.Equal(t, "file.env", args.EnvFile)
+			called++
+		},
+	}
+	cmd.PersistentFlags().AddFlag(args.ConfigFlag())
+	cmd.PersistentFlags().AddFlag(args.PrefixFlag())
+	cmd.SetArgs([]string{"--config", "file.env", "--prefix", "PF"})
+	require.NoError(t, cmd.Execute())
+	assert.Equal(t, 1, called)
+}

--- a/nconf/args_test.go
+++ b/nconf/args_test.go
@@ -37,7 +37,8 @@ PF_LOG_QUOTE_EMPTY_FIELDS=true
 		EnvFile: tmp.Name(),
 	}
 
-	log := args.Setup(cfg, "")
+	log, err := args.Setup(cfg, "")
+	require.NoError(t, err)
 
 	// check that we did call configure the logger
 	assert.NotNil(t, log)

--- a/nconf/bugsnag.go
+++ b/nconf/bugsnag.go
@@ -1,0 +1,31 @@
+package nconf
+
+import (
+	"github.com/bugsnag/bugsnag-go"
+	logrus_bugsnag "github.com/shopify/logrus-bugsnag"
+	"github.com/sirupsen/logrus"
+)
+
+type BugSnagConfig struct {
+	Environment string
+	APIKey      string `envconfig:"api_key"`
+}
+
+func AddBugSnagHook(config *BugSnagConfig) error {
+	if config == nil || config.APIKey == "" {
+		return nil
+	}
+
+	bugsnag.Configure(bugsnag.Configuration{
+		APIKey:       config.APIKey,
+		ReleaseStage: config.Environment,
+		PanicHandler: func() {}, // this is to disable panic handling. The lib was forking and restarting the process (causing races)
+	})
+	hook, err := logrus_bugsnag.NewBugsnagHook()
+	if err != nil {
+		return err
+	}
+	logrus.AddHook(hook)
+	logrus.Debug("Added bugsnag hook")
+	return nil
+}

--- a/nconf/logging.go
+++ b/nconf/logging.go
@@ -15,7 +15,7 @@ type LoggingConfig struct {
 	QuoteEmptyFields bool                   `mapstructure:"quote_empty_fields" split_words:"true" json:"quote_empty_fields"`
 	TSFormat         string                 `mapstructure:"ts_format" json:"ts_format"`
 	Fields           map[string]interface{} `mapstructure:"fields" json:"fields"`
-	UseNewLogger     bool                   `mapstructure:"use_new_logger", split_words:"true"`
+	UseNewLogger     bool                   `mapstructure:"use_new_logger",split_words:"true"`
 
 	BugSnag *BugSnagConfig
 }


### PR DESCRIPTION
We have a bunch services that re-implement configuration loading. This is an attempt at simplifying that.

What I'm thinking it is then used something like this:
```
args := new(nconf.RootArgs)
cmd := &cobra.Command{
  Run: func(_ *cobra.Command, _ []string) {
    config := conf.DefaultConfig()
    log := args.Setup(config)
    .....
  }
}
cmd.PersistentFlags().AddFlag(args.PrefixFlag())
cmd.PersistentFlags().AddFlag(args.ConfigFlag())
```

I'm def open to any stuff we can do to simplify that boiler plate.