### PR TITLE
Mount router health check as route instead of using a middleware

### DIFF
--- a/router/helpers.go
+++ b/router/helpers.go
@@ -19,3 +19,9 @@ func SendJSON(w http.ResponseWriter, status int, obj interface{}) error {
 	_, err = w.Write(b)
 	return err
 }
+
+// HandlerStatusOK is a APIHandler that just returns a 200 OK.
+func HandlerStatusOK(w http.ResponseWriter, _ *http.Request) *HTTPError {
+	w.WriteHeader(http.StatusOK)
+	return nil
+}

--- a/router/middleware.go
+++ b/router/middleware.go
@@ -79,17 +79,3 @@ func Recoverer(w http.ResponseWriter, r *http.Request, next http.Handler) {
 
 	next.ServeHTTP(w, r)
 }
-
-func HealthCheck(route string, f APIHandler) Middleware {
-	return MiddlewareFunc(func(w http.ResponseWriter, r *http.Request, next http.Handler) {
-		if r.URL.Path == route {
-			if f == nil {
-				w.WriteHeader(http.StatusOK)
-				return
-			}
-			HandleError(f(w, r), w, r)
-			return
-		}
-		next.ServeHTTP(w, r)
-	})
-}

--- a/router/router.go
+++ b/router/router.go
@@ -71,7 +71,12 @@ func New(log logrus.FieldLogger, options ...Option) Router {
 	}
 
 	if r.healthEndpoint != "" {
-		r.Use(HealthCheck(r.healthEndpoint, r.healthHandler))
+		h := r.healthHandler
+		if h == nil {
+			h = HandlerStatusOK
+		}
+
+		r.Get(r.healthEndpoint, h)
 	}
 	if r.enableTracing {
 		r.Use(tracing.Middleware(log, r.svcName))


### PR DESCRIPTION
After finding a bug in the `HealthCheck` middleware (See comment: TBD), I realise that simulating and endpoint via middleware instead of mounting it is not giving us any value. .

It makes more sense to directly mount the health check in the router since at the end it does not manipulates the request chain or triggers a side effect, being just the latest handler for its path.