### PR TITLE
add mapstructure command to struct

### DIFF
--- a/messaging/config.go
+++ b/messaging/config.go
@@ -42,9 +42,9 @@ type NatsConfig struct {
 }
 
 type NatsClientConfig struct {
-	NatsConfig
-	Subject string `mapstructure:"command_subject"`
-	Group   string `mapstructure:"command_group"`
+	NatsConfig `mapstructure:",squash"`
+	Subject    string `mapstructure:"command_subject"`
+	Group      string `mapstructure:"command_group"`
 
 	// StartAt will configure where the client should resume the stream:
 	// - `all`: all the messages available


### PR DESCRIPTION
This was something I forgot about. It is an annoying part of mapstructure.

![](https://en.bcdn.biz/Images/2015/9/24/f2ea3428-e726-402e-ad29-87a6bc018d70.jpg)