### PR TITLE
Introduce IgnoreCommand as a new config to BuildConfig

### DIFF
--- a/ntoml/netlify_toml.go
+++ b/ntoml/netlify_toml.go
@@ -36,11 +36,11 @@ type Settings struct {
 }
 
 type BuildConfig struct {
-	Command     string            `toml:"command"`
-	Base        string            `toml:"base"`
-	Publish     string            `toml:"publish"`
-	Ignore      string            `toml:"ignore"`
-	Environment map[string]string `toml:"environment"`
+	Command     string            `toml:"command" json:"command" yaml:"command"`
+	Base        string            `toml:"base" json:"base" yaml:"base"`
+	Publish     string            `toml:"publish" json:"publish" yaml:"publish"`
+	Ignore      string            `toml:"ignore" json:"ignore" yaml:"ignore"`
+	Environment map[string]string `toml:"environment" json:"environment" yaml:"environment"`
 }
 
 type DeployContext struct {


### PR DESCRIPTION
This is a new config we are rolling for monoreport and supporting it in commons.

Being introduced in https://github.com/netlify/buildbot/pull/472
#458

- [x] Wait for above PR to ship before merging this (in case attribute name changes)