### PR TITLE
API lifecycle support

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -85,7 +85,11 @@ func (s *Server) ListenAndServe() error {
 	}
 
 	// Now that server is no longer listening, shutdown the API
+	s.log.Info("Listener shutdown, stopping API")
+
 	s.api.Stop()
+
+	s.log.Debug("Completed shutting down the underlying API")
 
 	if err == http.ErrServerClosed {
 		return nil

--- a/server/server.go
+++ b/server/server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"time"
 
 	"github.com/netlify/netlify-commons/nconf"
@@ -90,6 +91,10 @@ func (s *Server) ListenAndServe() error {
 		return nil
 	}
 	return err
+}
+
+func (s *Server) TestServer() *httptest.Server {
+	return httptest.NewServer(s.svr.Handler)
 }
 
 type apiFunc struct {

--- a/server/server.go
+++ b/server/server.go
@@ -17,6 +17,7 @@ import (
 type Server struct {
 	log logrus.FieldLogger
 	svr *http.Server
+	api APIDefinition
 }
 
 type Config struct {
@@ -25,9 +26,10 @@ type Config struct {
 	TLS        nconf.TLSConfig
 }
 
-// APIDefinition is used to define the routes used by the API
+// APIDefinition is used to control lifecycle of the API
 type APIDefinition interface {
-	AddRoutes(r router.Router)
+	Start(r router.Router) error
+	Stop()
 }
 
 func New(log logrus.FieldLogger, projectName string, config Config, api APIDefinition) (*Server, error) {
@@ -37,7 +39,9 @@ func New(log logrus.FieldLogger, projectName string, config Config, api APIDefin
 		router.OptTracingMiddleware(log, projectName),
 	)
 
-	api.AddRoutes(r)
+	if err := api.Start(r); err != nil {
+		return nil, errors.Wrap(err, "Failed to start API")
+	}
 
 	s := Server{
 		log: log.WithField("component", "server"),
@@ -45,6 +49,7 @@ func New(log logrus.FieldLogger, projectName string, config Config, api APIDefin
 			Addr:    fmt.Sprintf(":%d", config.Port),
 			Handler: r,
 		},
+		api: api,
 	}
 
 	if config.TLS.Enabled {
@@ -77,6 +82,10 @@ func (s *Server) ListenAndServe() error {
 	} else {
 		err = s.svr.ListenAndServe()
 	}
+
+	// Now that server is no longer listening, shutdown the API
+	s.api.Stop()
+
 	if err == http.ErrServerClosed {
 		return nil
 	}
@@ -84,13 +93,21 @@ func (s *Server) ListenAndServe() error {
 }
 
 type apiFunc struct {
-	f func(router.Router)
+	start func(router.Router) error
+	stop  func()
 }
 
-func (a apiFunc) AddRoutes(r router.Router) {
-	a.f(r)
+func (a apiFunc) Start(r router.Router) error {
+	return a.start(r)
 }
 
-func APIFunc(f func(router.Router)) APIDefinition {
-	return apiFunc{f}
+func (a apiFunc) Stop() {
+	a.stop()
+}
+
+func APIFunc(start func(router.Router) error, stop func()) APIDefinition {
+	return apiFunc{
+		start: start,
+		stop:  stop,
+	}
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1,16 +1,15 @@
 package server
 
 import (
+	"github.com/netlify/netlify-commons/router"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
-
-	"github.com/netlify/netlify-commons/router"
-	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func init() {
@@ -20,11 +19,16 @@ func init() {
 }
 
 func TestServerHealth(t *testing.T) {
-	apiDef := APIFunc(func(r router.Router) {
-		r.Get("/", func(w http.ResponseWriter, r *http.Request) *router.HTTPError {
+	apiDef := APIFunc(
+		func(r router.Router) error {
+			r.Get("/", func(w http.ResponseWriter, r *http.Request) *router.HTTPError {
+				return nil
+			})
 			return nil
-		})
-	})
+		},
+		func() {
+		},
+	)
 
 	cfg := testConfig()
 	svr, err := New(tl(t), "testing", cfg, apiDef)


### PR DESCRIPTION
This tweaks the `APIDefinition` interface to include full lifecycle support (Start + Stop). This allows the API to perform a clean shutdown like releasing and removing Consul locks. This was the remaining piece to allow Eventeer to remove its Server implementation.