### PR TITLE
Allow a server api to implement a custom healthcheck

### DIFF
--- a/router/middleware.go
+++ b/router/middleware.go
@@ -90,9 +90,7 @@ func HealthCheck(route string, f APIHandler) Middleware {
 				w.WriteHeader(http.StatusOK)
 				return
 			}
-			if err := f(w, r); err != nil {
-				HandleError(f(w, r), w, r)
-			}
+			HandleError(f(w, r), w, r)
 			return
 		}
 		next.ServeHTTP(w, r)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1,15 +1,16 @@
 package server
 
 import (
-	"github.com/netlify/netlify-commons/router"
-	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/netlify/netlify-commons/router"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func init() {
@@ -40,6 +41,36 @@ func TestServerHealth(t *testing.T) {
 	rsp, err := http.Get(testSvr.URL + cfg.HealthPath)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, rsp.StatusCode)
+}
+
+type testAPICustomHealth struct{}
+
+func (a *testAPICustomHealth) Start(r router.Router) error {
+	r.Get("/", func(w http.ResponseWriter, r *http.Request) *router.HTTPError {
+		return nil
+	})
+	return nil
+}
+
+func (a *testAPICustomHealth) Stop() {}
+
+func (a *testAPICustomHealth) Healthy(w http.ResponseWriter, r *http.Request) *router.HTTPError {
+	return router.InternalServerError("healthcheck failed")
+}
+
+func TestServerCustomHealth(t *testing.T) {
+	apiDef := new(testAPICustomHealth)
+
+	cfg := testConfig()
+	svr, err := New(tl(t), "testing", cfg, apiDef)
+	require.NoError(t, err)
+
+	testSvr := httptest.NewServer(svr.svr.Handler)
+	defer testSvr.Close()
+
+	rsp, err := http.Get(testSvr.URL + cfg.HealthPath)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusInternalServerError, rsp.StatusCode)
 }
 
 func tl(t *testing.T) *logrus.Entry {


### PR DESCRIPTION
## Summary

Whenever an api implements the `Healthy` method, it will be used to run a custom healthcheck.

## Test plan

- Tests added

## Cute animal

![](https://www.collinsdictionary.com/images/full/gopher_438742864.jpg)