### PR TITLE
fix(router): early return when zero vallue of err in HandleError

### DIFF
--- a/router/errors.go
+++ b/router/errors.go
@@ -3,6 +3,7 @@ package router
 import (
 	"fmt"
 	"net/http"
+	"unsafe"
 
 	"github.com/netlify/netlify-commons/tracing"
 )
@@ -85,7 +86,8 @@ func httpError(code int, fmtString string, args ...interface{}) *HTTPError {
 
 // HandleError will handle an error
 func HandleError(err error, w http.ResponseWriter, r *http.Request) {
-	if err == nil {
+	// if err is nil or nil pointer of type *HTTPError
+	if err == nil || (*[2]uintptr)(unsafe.Pointer(&err))[1] == 0 {
 		return
 	}
 

--- a/router/middleware.go
+++ b/router/middleware.go
@@ -90,7 +90,11 @@ func HealthCheck(route string, f APIHandler) Middleware {
 				w.WriteHeader(http.StatusOK)
 				return
 			}
-			HandleError(f(w, r), w, r)
+
+			if err := f(w, r); err != nil {
+				HandleError(err, w, r)
+			}
+
 			return
 		}
 		next.ServeHTTP(w, r)


### PR DESCRIPTION
## Issue

Router component wasn't able to handle nil pointer to type `HTTPError`, meaning the following simple handler 

```go
func(_ http.ResponseWriter, _ *http.Request) *HTTPError {
	return nil
}
```

was ending with a panic:
```
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
```

## Reason

`return nil` is returning a nil pointer to type `HTTPError`, which is later on passed to https://github.com/netlify/netlify-commons/blob/91f500e0a2b59a8667d48df8f2cbeea2160da991/router/errors.go#L88

As you can see, the first arguments expects the interface `error`, which is completely fulfilled.
According to [Go FAQS](https://golang.org/doc/faq#nil_error):
> An interface value is nil only if the V and T are both unset

In that case, value is `nil` by type is `*HTTPError` so when this check gave a `false`.
https://github.com/netlify/netlify-commons/blob/eb929b04d4fa127aeb87ecb2ba7d54bad1009049/router/errors.go#L88-L90

## Fix

The ideal fix is checking for `== nil` before calling `HandleError` func as I did here: https://github.com/netlify/netlify-commons/blob/f082f63c611840b9db35a13070e774bd591421c2/router/middleware.go#L94-L96
The main issue is that we could easily fall into doing the same mistake in the future. That's the reason I decided to add an extra check in `HandleError`. The first idea was to use `reflect.ValueOf(err).IsNil()` but then, concerned about performance, I found [this article](https://dev.to/pauljlucas/go-tcha-when-nil--nil-hic) where they suggest to use the `unsafe` package instead with https://github.com/netlify/netlify-commons/blob/f082f63c611840b9db35a13070e774bd591421c2/router/errors.go#L90


