### PR TITLE
Fix panic in ntoml when checking paths

### DIFF
--- a/ntoml/netlify_toml.go
+++ b/ntoml/netlify_toml.go
@@ -87,7 +87,7 @@ func findOnlyOneExistingPath(base string, paths ...string) (path string, err err
 	foundPaths := make([]string, 0, len(paths))
 	for _, possiblePath := range paths {
 		p := filepath.Join(base, possiblePath)
-		if fi, err := os.Stat(p); !os.IsNotExist(err) && !fi.IsDir() {
+		if fi, err := os.Stat(p); err != nil && !fi.IsDir() {
 			foundPaths = append(foundPaths, p)
 		}
 	}

--- a/ntoml/netlify_toml.go
+++ b/ntoml/netlify_toml.go
@@ -84,11 +84,9 @@ func (f *FoundMoreThanOneConfigPathError) Error() string {
 }
 
 func findOnlyOneExistingPath(base string, paths ...string) (path string, err error) {
-	joinedPaths := make([]string, 0, len(paths))
 	foundPaths := make([]string, 0, len(paths))
 	for _, possiblePath := range paths {
 		p := filepath.Join(base, possiblePath)
-		joinedPaths = append(joinedPaths, p)
 		if fi, err := os.Stat(p); !os.IsNotExist(err) && !fi.IsDir() {
 			foundPaths = append(foundPaths, p)
 		}


### PR DESCRIPTION
Buildbot can panic with an error like this: [humio link](https://cloud.us.humio.com/netlify-us-production/search?query=kubernetes.pod.name%3Dbuild-5eba58546f64a8f0f1a0b34d&live=false&start=1589269284331&end=1589272215404&fullscreen=false&widgetType=list-view&columns=%40rawstring%3A%3Aauto&newestAtBottom=true&showOnlyFirstLine=false)

We're attempting to stat a filepath in this code, but only checking for one error case: that the file wasn't found.

I'm guessing we're hitting permission denied because the user provided a path outside the working directory (https://golang.org/pkg/os/#IsPermission)

I think it would be nice to warn if we're ignoring some path because of an error, but we don't have access to a logger here and returning early with the error would cause us to fail builds that could have proceeded with some other path.

Fixes https://github.com/netlify/buildbot/issues/742