### PR TITLE
Fix err check in ntoml path checker

### DIFF
--- a/ntoml/netlify_toml.go
+++ b/ntoml/netlify_toml.go
@@ -87,7 +87,7 @@ func findOnlyOneExistingPath(base string, paths ...string) (path string, err err
 	foundPaths := make([]string, 0, len(paths))
 	for _, possiblePath := range paths {
 		p := filepath.Join(base, possiblePath)
-		if fi, err := os.Stat(p); err != nil && !fi.IsDir() {
+		if fi, err := os.Stat(p); err == nil && !fi.IsDir() {
 			foundPaths = append(foundPaths, p)
 		}
 	}

--- a/ntoml/netlify_toml_test.go
+++ b/ntoml/netlify_toml_test.go
@@ -231,3 +231,15 @@ context:
 
 	return tmp
 }
+
+func TestFindOnlyOneExistingPath(t *testing.T) {
+	_, err := findOnlyOneExistingPath("", "does-not-exist")
+	assert.IsType(t, &FoundNoConfigPathError{}, err)
+
+	tmp, err := ioutil.TempFile("", "netlify-*.yaml")
+	require.NoError(t, err)
+	defer os.Remove(tmp.Name())
+	path, err := findOnlyOneExistingPath("", tmp.Name())
+	assert.NoError(t, err)
+	assert.Equal(t, tmp.Name(), path)
+}


### PR DESCRIPTION
Made a small mistake in my last PR :upside_down_face: 

We want to check that the error *is* nil when we stat the file. Added a test to catch this.