### PR TITLE
Add plugin package names to netlify.toml

### DIFF
--- a/ntoml/netlify_toml.go
+++ b/ntoml/netlify_toml.go
@@ -42,6 +42,11 @@ type BuildConfig struct {
 	Publish     string            `toml:"publish" json:"publish" yaml:"publish"`
 	Ignore      string            `toml:"ignore" json:"ignore" yaml:"ignore"`
 	Environment map[string]string `toml:"environment" json:"environment" yaml:"environment"`
+	Plugins     []Plugin          `toml:"plugins" json:"plugins" yaml:"plugins"`
+}
+
+type Plugin struct {
+	Package string `toml:"package" json:"package" yaml:"package"`
 }
 
 type DeployContext struct {


### PR DESCRIPTION
We serialize the config returned by Netlify Config back to this type. Only including package name for now, since that's the only plugins field that will be handled by Buildbot for plugins GA.

Part of https://github.com/netlify/buildbot/issues/746