### PR TITLE
Set final field with context.

### DIFF
--- a/tracing/logging.go
+++ b/tracing/logging.go
@@ -63,11 +63,15 @@ func SetLogFields(r *http.Request, fields logrus.Fields) logrus.FieldLogger {
 // SetFinalField will add a field to the canonical line created at in Finish. It will add
 // it to this line, but not every log line in between
 func SetFinalField(r *http.Request, key string, value interface{}) logrus.FieldLogger {
-	entry := GetTracer(r)
+	return SetFinalFieldWithContext(r.Context(), key, value)
+}
+
+// SetFinalFieldWithContext will add a field to the canonical line created at in Finish. It will add
+// it to this line, but not every log line in between
+func SetFinalFieldWithContext(ctx context.Context, key string, value interface{}) logrus.FieldLogger {
+	entry := GetFromContext(ctx)
 	if entry == nil {
 		return logrus.StandardLogger().WithField(key, value)
 	}
-
-	entry.FinalFields[key] = value
-	return entry.FieldLogger.WithField(key, value)
+	return entry.SetFinalField(key, value)
 }

--- a/tracing/req_tracer.go
+++ b/tracing/req_tracer.go
@@ -13,7 +13,7 @@ type RequestTracer struct {
 	logrus.FieldLogger
 
 	RequestID   string
-	FinalFields map[string]interface{}
+	finalFields map[string]interface{}
 
 	remoteAddr  string
 	method      string
@@ -42,7 +42,7 @@ func NewTracer(w http.ResponseWriter, r *http.Request, log logrus.FieldLogger, s
 		span:           span,
 		trackingWriter: trackWriter,
 		FieldLogger:    log,
-		FinalFields:    make(map[string]interface{}),
+		finalFields:    make(map[string]interface{}),
 	}
 	r = WrapWithTracer(r, rt)
 
@@ -63,7 +63,7 @@ func (rt *RequestTracer) Finish() {
 	dur := time.Since(rt.start)
 
 	fields := logrus.Fields{}
-	for k, v := range rt.FinalFields {
+	for k, v := range rt.finalFields {
 		fields[k] = v
 	}
 
@@ -86,4 +86,9 @@ func (rt *RequestTracer) SetLogField(key string, value interface{}) logrus.Field
 func (rt *RequestTracer) SetLogFields(fields logrus.Fields) logrus.FieldLogger {
 	rt.FieldLogger = rt.FieldLogger.WithFields(fields)
 	return rt.FieldLogger
+}
+
+func (rt *RequestTracer) SetFinalField(key string, value interface{}) logrus.FieldLogger {
+	rt.finalFields[key] = value
+	return rt.FieldLogger.WithField(key, value)
 }


### PR DESCRIPTION
Add method to set a final field given a context.
This is useful when you want to add entries to the canonical api log from a component called by a request handler.

Signed-off-by: David Calavera <david.calavera@gmail.com>