### PR TITLE
fix(metriks): force empty Datadog sink hostname. Service name always in prefix.

### DIFF
--- a/metriks/config.go
+++ b/metriks/config.go
@@ -4,7 +4,8 @@ type Config struct {
 	Host string `default:"localhost"`
 	Port int    `default:"8125"`
 
-	// Name is typically the local hostname or pod name
-	Name string `default:"local"`
 	Tags map[string]string
+
+	// Deprecated: Name is not needed anymore.
+	Name string
 }

--- a/metriks/config.go
+++ b/metriks/config.go
@@ -5,7 +5,4 @@ type Config struct {
 	Port int    `default:"8125"`
 
 	Tags map[string]string
-
-	// Deprecated: Name is not needed anymore.
-	Name string
 }

--- a/metriks/metriks.go
+++ b/metriks/metriks.go
@@ -20,7 +20,7 @@ func Init(serviceName string, conf Config) error {
 
 // InitTags behaves like Init but allows appending extra tags
 func InitTags(serviceName string, conf Config, extraTags []string) error {
-	sink, err := createDatadogSink(statsdAddr(conf), conf.Name, conf.Tags, extraTags)
+	sink, err := createDatadogSink(statsdAddr(conf), "", conf.Tags, extraTags)
 	if err != nil {
 		return err
 	}

--- a/metriks/metriks_test.go
+++ b/metriks/metriks_test.go
@@ -19,7 +19,6 @@ func TestMetriksInit(t *testing.T) {
 	config := Config{
 		Host: "127.0.0.1",
 		Port: 8125,
-		Name: "dev-test",
 		Tags: nil,
 	}
 	err = Init("foo", config)


### PR DESCRIPTION
`Name` config field maps to Datadog sink `hostname` field. It is only used by
armon/go-metrics lib and in a really non-well documented way.

It is basically used for removing from the metrics key the hostname in
favor of adding it (manually by the user) as tag. The library creator
explains that it makes sense since Datadog is multidimensional so the
tags should be used instead.
This is causing issues like sending metrics without the expected prefix: I.e.:

- Expected: `my-app.hits`
- Got: `hits`

See https://github.com/armon/go-metrics/blob/master/datadog/dogstatsd.go#L63-L82

We totally disagree.