### PR TITLE
change the APIHandler add the Recoverer

### DIFF
--- a/router/errors.go
+++ b/router/errors.go
@@ -106,7 +106,7 @@ func HandleError(err error, w http.ResponseWriter, r *http.Request) {
 		}
 
 		if jsonErr := SendJSON(w, e.Code, e); jsonErr != nil {
-			HandleError(jsonErr, w, r)
+			log.WithError(jsonErr).Error("Failed to write the JSON error response")
 		}
 	default:
 		// this is 5ns slower than using unsafe but a unhandled internal server error should not happen that often

--- a/router/errors.go
+++ b/router/errors.go
@@ -12,7 +12,7 @@ import (
 type HTTPError struct {
 	Code            int         `json:"code"`
 	Message         string      `json:"msg"`
-	JSON            interface{} `json:"json"`
+	JSON            interface{} `json:"json,omitempty"`
 	InternalError   error       `json:"-"`
 	InternalMessage string      `json:"-"`
 	ErrorID         string      `json:"error_id,omitempty"`

--- a/router/errors_test.go
+++ b/router/errors_test.go
@@ -87,7 +87,7 @@ func TestHandleError_HTTPError(t *testing.T) {
 	b, err := ioutil.ReadAll(resp.Body)
 	require.NoError(t, err)
 
-	expectedBody := fmt.Sprintf(`{"code":500,"msg":"Internal Server Error","json":null,"error_id":"%s"}`, tracing.RequestID(r))
+	expectedBody := fmt.Sprintf(`{"code":500,"msg":"Internal Server Error","error_id":"%s"}`, tracing.RequestID(r))
 	assert.Equal(t, expectedBody, string(b))
 
 	require.Len(t, loggerOutput.AllEntries(), 1)

--- a/router/middleware_test.go
+++ b/router/middleware_test.go
@@ -19,7 +19,7 @@ func TestCheckAuth(t *testing.T) {
 	makeRequest := func(req *http.Request) *httptest.ResponseRecorder {
 		r := New(logrus.WithField("test", "CheckAuth"))
 		r.Use(CheckAuth(validKey))
-		r.Get("/", func(w http.ResponseWriter, r *http.Request) *HTTPError {
+		r.Get("/", func(w http.ResponseWriter, r *http.Request) error {
 			return nil
 		})
 		rec := httptest.NewRecorder()

--- a/router/options.go
+++ b/router/options.go
@@ -33,3 +33,9 @@ func OptTracingMiddleware(log logrus.FieldLogger, svcName string) Option {
 		r.enableTracing = true
 	}
 }
+
+func OptRecoverer() Option {
+	return func(r *chiWrapper) {
+		r.enableRecover = true
+	}
+}

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -31,7 +31,7 @@ func TestCallthrough(t *testing.T) {
 	require.NoError(t, err)
 
 	var callCount int
-	handler := func(w http.ResponseWriter, r *http.Request) *HTTPError {
+	handler := func(w http.ResponseWriter, r *http.Request) error {
 		callCount++
 		return BadRequestError("")
 	}
@@ -52,12 +52,11 @@ func TestHealthEndpoint(t *testing.T) {
 		"default":  {[]Option{OptHealthCheck("/health", nil)}, http.StatusOK},
 		"custom": {[]Option{OptHealthCheck(
 			"/health",
-			func(_ http.ResponseWriter, r *http.Request) *HTTPError {
+			func(_ http.ResponseWriter, r *http.Request) error {
 				return UnauthorizedError("")
 			})},
 			http.StatusUnauthorized},
 	}
-
 
 	for name, scene := range scenarios {
 		t.Run(name, func(t *testing.T) {
@@ -96,7 +95,7 @@ func do(t *testing.T, opts []Option, svcName, path string, handler APIHandler, r
 	r := New(logrus.WithField("test", t.Name()), opts...)
 
 	if handler == nil {
-		handler = func(w http.ResponseWriter, r *http.Request) *HTTPError {
+		handler = func(w http.ResponseWriter, r *http.Request) error {
 			return nil
 		}
 	}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -22,7 +22,7 @@ func init() {
 func TestServerHealth(t *testing.T) {
 	apiDef := APIFunc(
 		func(r router.Router) error {
-			r.Get("/", func(w http.ResponseWriter, r *http.Request) *router.HTTPError {
+			r.Get("/", func(w http.ResponseWriter, r *http.Request) error {
 				return nil
 			})
 			return nil
@@ -32,7 +32,7 @@ func TestServerHealth(t *testing.T) {
 	)
 
 	cfg := testConfig()
-	svr, err := New(tl(t), "testing", cfg, apiDef)
+	svr, err := New(tl(t), "testing", "", cfg, apiDef)
 	require.NoError(t, err)
 
 	testSvr := httptest.NewServer(svr.svr.Handler)
@@ -43,10 +43,45 @@ func TestServerHealth(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rsp.StatusCode)
 }
 
+func TestServerVersioning(t *testing.T) {
+	apiDef := APIFunc(
+		func(r router.Router) error {
+			r.Get("/", func(w http.ResponseWriter, r *http.Request) error {
+				return nil
+			})
+			return nil
+		},
+		func() {
+		},
+	)
+	cfg := testConfig()
+	t.Run("with-no-version", func(t *testing.T) {
+		svr, err := New(tl(t), "testing", "", cfg, apiDef)
+		require.NoError(t, err)
+		testSvr := httptest.NewServer(svr.svr.Handler)
+		defer testSvr.Close()
+		rsp, err := http.Get(testSvr.URL + cfg.HealthPath)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, rsp.StatusCode)
+		assert.Equal(t, "unknown", rsp.Header.Get("X-Nf-Testing-Version"))
+	})
+	t.Run("with-version", func(t *testing.T) {
+		svr, err := New(tl(t), "testing", "123", cfg, apiDef)
+		require.NoError(t, err)
+		testSvr := httptest.NewServer(svr.svr.Handler)
+		defer testSvr.Close()
+		rsp, err := http.Get(testSvr.URL + cfg.HealthPath)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, rsp.StatusCode)
+		assert.Equal(t, "123", rsp.Header.Get("X-Nf-testing-version"))
+	})
+
+}
+
 type testAPICustomHealth struct{}
 
 func (a *testAPICustomHealth) Start(r router.Router) error {
-	r.Get("/", func(w http.ResponseWriter, r *http.Request) *router.HTTPError {
+	r.Get("/", func(w http.ResponseWriter, r *http.Request) error {
 		return nil
 	})
 	return nil
@@ -54,7 +89,7 @@ func (a *testAPICustomHealth) Start(r router.Router) error {
 
 func (a *testAPICustomHealth) Stop() {}
 
-func (a *testAPICustomHealth) Healthy(w http.ResponseWriter, r *http.Request) *router.HTTPError {
+func (a *testAPICustomHealth) Healthy(w http.ResponseWriter, r *http.Request) error {
 	return router.InternalServerError("healthcheck failed")
 }
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -97,7 +97,7 @@ func TestServerCustomHealth(t *testing.T) {
 	apiDef := new(testAPICustomHealth)
 
 	cfg := testConfig()
-	svr, err := New(tl(t), "testing", cfg, apiDef)
+	svr, err := New(tl(t), "testing", "", cfg, apiDef)
 	require.NoError(t, err)
 
 	testSvr := httptest.NewServer(svr.svr.Handler)


### PR DESCRIPTION
* Adds the option (and defaults on) a recoverer middleware
* changes the `APIHandler` to use `error`

The latter is because of learnings from: https://golang.org/doc/faq#nil_error (thanks @smoya!). It should be transparent to code using it. If using the `HandleError` it already handles this case

If this gets merged I think we should up the version number to indicate a breaking change.