### PR TITLE
make tracing and metrics part of the default config

### DIFF
--- a/metriks/config.go
+++ b/metriks/config.go
@@ -1,8 +1,9 @@
 package metriks
 
 type Config struct {
-	Host string `default:"localhost"`
-	Port int    `default:"8125"`
+	Enabled bool
+	Host    string `default:"localhost"`
+	Port    int    `default:"8125"`
 
 	Tags map[string]string
 }

--- a/metriks/metriks.go
+++ b/metriks/metriks.go
@@ -20,6 +20,10 @@ func Init(serviceName string, conf Config) error {
 
 // InitTags behaves like Init but allows appending extra tags
 func InitTags(serviceName string, conf Config, extraTags []string) error {
+	if !conf.Enabled {
+		return nil
+	}
+
 	sink, err := createDatadogSink(statsdAddr(conf), "", conf.Tags, extraTags)
 	if err != nil {
 		return err

--- a/nconf/args_test.go
+++ b/nconf/args_test.go
@@ -37,7 +37,7 @@ PF_LOG_QUOTE_EMPTY_FIELDS=true
 		EnvFile: tmp.Name(),
 	}
 
-	log, err := args.Setup(cfg, "")
+	log, err := args.Setup(cfg, "", "")
 	require.NoError(t, err)
 
 	// check that we did call configure the logger


### PR DESCRIPTION
The goal here is to have a standard names and configuration that people can use. We can change the boilerplate templates used to provide these by default too.

This is slightly breaking change in that you have to provide the "serviceName" to the args now. We should consider unifying the other calls (e.g. in `server`) too.