### PR TITLE
make the request ID accessible from context

### DIFF
--- a/router/errors.go
+++ b/router/errors.go
@@ -87,7 +87,7 @@ func httpError(code int, fmtString string, args ...interface{}) *HTTPError {
 // HandleError will handle an error
 func HandleError(err error, w http.ResponseWriter, r *http.Request) {
 	log := tracing.GetLogger(r)
-	errorID := tracing.RequestID(r)
+	errorID := tracing.GetRequestID(r)
 	switch e := err.(type) {
 	case nil:
 		return

--- a/router/errors_test.go
+++ b/router/errors_test.go
@@ -87,7 +87,7 @@ func TestHandleError_HTTPError(t *testing.T) {
 	b, err := ioutil.ReadAll(resp.Body)
 	require.NoError(t, err)
 
-	expectedBody := fmt.Sprintf(`{"code":500,"msg":"Internal Server Error","error_id":"%s"}`, tracing.RequestID(r))
+	expectedBody := fmt.Sprintf(`{"code":500,"msg":"Internal Server Error","error_id":"%s"}`, tracing.GetRequestID(r))
 	assert.Equal(t, expectedBody, string(b))
 
 	require.Len(t, loggerOutput.AllEntries(), 1)

--- a/router/middleware.go
+++ b/router/middleware.go
@@ -75,7 +75,7 @@ func Recoverer(errLog logrus.FieldLogger) Middleware {
 					logger.Out = os.Stderr
 					errLog = logrus.NewEntry(logger)
 				}
-				reqID := tracing.RequestID(r)
+				reqID := tracing.GetRequestID(r)
 				panicLog := errLog.WithField("request_id", reqID)
 
 				stack := debug.Stack()

--- a/tracing/context.go
+++ b/tracing/context.go
@@ -28,3 +28,15 @@ func GetFromContext(ctx context.Context) *RequestTracer {
 func GetTracer(r *http.Request) *RequestTracer {
 	return GetFromContext(r.Context())
 }
+
+func GetRequestID(r *http.Request) string {
+	return GetRequestIDFromContext(r.Context())
+}
+
+func GetRequestIDFromContext(ctx context.Context) string {
+	tr := GetFromContext(ctx)
+	if tr == nil {
+		return ""
+	}
+	return tr.RequestID
+}

--- a/tracing/logging.go
+++ b/tracing/logging.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 
+	uuid "github.com/satori/go.uuid"
 	"github.com/sirupsen/logrus"
 )
 
@@ -21,11 +22,16 @@ func requestLogger(r *http.Request, log logrus.FieldLogger) (logrus.FieldLogger,
 		}
 	}
 
-	reqID := RequestID(r)
+	reqID := r.Header.Get(HeaderRequestUUID)
+	if reqID == "" {
+		reqID = uuid.NewV4().String()
+		r.Header.Set(HeaderRequestUUID, reqID)
+	}
 
 	log = log.WithFields(logrus.Fields{
 		"request_id": reqID,
 	})
+
 	return log, reqID
 }
 

--- a/tracing/logging.go
+++ b/tracing/logging.go
@@ -11,7 +11,7 @@ const (
 	logKey = contextKey("nf-log-key")
 )
 
-func requestLogger(r *http.Request, log logrus.FieldLogger) logrus.FieldLogger {
+func requestLogger(r *http.Request, log logrus.FieldLogger) (logrus.FieldLogger, string) {
 	if r.Header.Get(HeaderNFDebugLogging) != "" {
 		logger := logrus.New()
 		logger.SetLevel(logrus.DebugLevel)
@@ -26,7 +26,7 @@ func requestLogger(r *http.Request, log logrus.FieldLogger) logrus.FieldLogger {
 	log = log.WithFields(logrus.Fields{
 		"request_id": reqID,
 	})
-	return log
+	return log, reqID
 }
 
 func GetLoggerFromContext(ctx context.Context) logrus.FieldLogger {

--- a/tracing/req_tracer.go
+++ b/tracing/req_tracer.go
@@ -24,8 +24,9 @@ type RequestTracer struct {
 }
 
 func NewTracer(w http.ResponseWriter, r *http.Request, log logrus.FieldLogger, service string) (http.ResponseWriter, *http.Request, *RequestTracer) {
-	reqID := RequestID(r)
-	log = requestLogger(r, log)
+	var reqID string
+	log, reqID = requestLogger(r, log)
+
 	r, span := WrapWithSpan(r, reqID, service)
 	trackWriter := &trackingWriter{
 		writer: w,

--- a/tracing/tracer.go
+++ b/tracing/tracer.go
@@ -6,7 +6,6 @@ import (
 
 	opentracing "github.com/opentracing/opentracing-go"
 	ext "github.com/opentracing/opentracing-go/ext"
-	uuid "github.com/satori/go.uuid"
 	"github.com/sirupsen/logrus"
 	ddtrace_ext "gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/opentracer"
@@ -17,22 +16,6 @@ func TrackRequest(w http.ResponseWriter, r *http.Request, log logrus.FieldLogger
 	rt.Start()
 	next.ServeHTTP(w, r)
 	rt.Finish()
-}
-
-func RequestID(r *http.Request) string {
-	id := r.Header.Get(HeaderRequestUUID)
-	if id != "" {
-		return id
-	}
-
-	id = GetRequestID(r)
-	if id != "" {
-		return id
-	}
-
-	id = uuid.NewV4().String()
-	r.Header.Set(HeaderRequestUUID, id)
-	return id
 }
 
 func WrapWithSpan(r *http.Request, reqID, service string) (*http.Request, opentracing.Span) {

--- a/tracing/tracer.go
+++ b/tracing/tracer.go
@@ -21,10 +21,17 @@ func TrackRequest(w http.ResponseWriter, r *http.Request, log logrus.FieldLogger
 
 func RequestID(r *http.Request) string {
 	id := r.Header.Get(HeaderRequestUUID)
-	if id == "" {
-		id = uuid.NewV4().String()
-		r.Header.Set(HeaderRequestUUID, id)
+	if id != "" {
+		return id
 	}
+
+	id = GetRequestID(r)
+	if id != "" {
+		return id
+	}
+
+	id = uuid.NewV4().String()
+	r.Header.Set(HeaderRequestUUID, id)
 	return id
 }
 


### PR DESCRIPTION
In cert-store we were trying to pull the request ID from the context, so we had to jam it in there. This is probably a common pattern (e.g. going to make a secondary request).

I decided to use the `Tracer` (vs adding an explicit key) so that there was no chance of drift. Plus it made it easy. I'm def open if people don't like this (I kinda don't like this whole package).