### PR TITLE
Upgrade to Go 1.15

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,10 +6,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.13.x', '1.14.x']
+        go: ["1.14.x", "1.15.x"]
     steps:
-    - uses: actions/checkout@master
-    - uses: actions/setup-go@v1
-      with:
-        go-version: ${{ matrix.go }} # The Go version to download (if necessary) and use.
-    - run: make deps build test
+      - uses: actions/checkout@master
+      - uses: actions/setup-go@v1
+        with:
+          go-version: ${{ matrix.go }} # The Go version to download (if necessary) and use.
+      - run: make deps build test

--- a/go.mod
+++ b/go.mod
@@ -38,4 +38,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.0-20190924164351-c8b7dadae555
 )
 
-go 1.13
+go 1.14


### PR DESCRIPTION
Recently released. I think supporting latest two is the default.