### PR TITLE
make start stop events for a service

### DIFF
--- a/metriks/metriks.go
+++ b/metriks/metriks.go
@@ -24,7 +24,7 @@ func InitTags(serviceName string, conf Config, extraTags []string) error {
 		return nil
 	}
 
-	sink, err := createDatadogSink(statsdAddr(conf), "", conf.Tags, extraTags)
+	sink, err := createDatadogSink(conf.StatsdAddr(), "", conf.Tags, extraTags)
 	if err != nil {
 		return err
 	}
@@ -210,6 +210,6 @@ func GaugeLabels(name string, labels []metrics.Label, val float32) {
 	Gauge(name, val, labels...)
 }
 
-func statsdAddr(conf Config) string {
+func (conf Config) StatsdAddr() string {
 	return fmt.Sprintf("%s:%d", conf.Host, conf.Port)
 }

--- a/nconf/args.go
+++ b/nconf/args.go
@@ -47,6 +47,10 @@ func (args *RootArgs) Setup(config interface{}, serviceName, version string) (lo
 	// Handles the 'enabled' flag itself
 	tracing.Configure(&rootConfig.Tracing, serviceName)
 
+	if err := sendDatadogEvents(rootConfig.Metrics, serviceName, version); err != nil {
+		log.WithError(err).Error("Failed to send the startup events to datadog")
+	}
+
 	if config != nil {
 		// second load the config for this project
 		if err := LoadFromEnv(args.Prefix, args.EnvFile, config); err != nil {

--- a/nconf/events.go
+++ b/nconf/events.go
@@ -1,0 +1,62 @@
+package nconf
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	ddstatsd "github.com/DataDog/datadog-go/statsd"
+	"github.com/netlify/netlify-commons/metriks"
+	"github.com/pkg/errors"
+)
+
+func sendDatadogEvents(conf metriks.Config, serviceName, version string) error {
+	if !conf.Enabled {
+		return nil
+	}
+
+	client, err := ddstatsd.New(conf.StatsdAddr())
+	if err != nil {
+		return errors.Wrap(err, "failed to connect to datadog agent")
+	}
+
+	tags := []string{
+		fmt.Sprintf("version:%s", version),
+		fmt.Sprintf("service:%s", serviceName),
+	}
+	host, err := os.Hostname()
+	if err != nil {
+		return errors.Wrap(err, "failed to get the hostname")
+	}
+
+	key := "hostname"
+	if val := os.Getenv("KUBERNETES_PORT"); val != "" {
+		key = "pod"
+	}
+	tags = append(tags, fmt.Sprintf("%s:%s", key, host))
+
+	start := &ddstatsd.Event{
+		Tags:  append(tags, "event_type:startup"),
+		Title: fmt.Sprintf("Service Start: %s", serviceName),
+		Text:  fmt.Sprintf("Service %s @ %s is starting", serviceName, version),
+	}
+	if err := client.Event(start); err != nil {
+		return errors.Wrap(err, "failed to send startup event")
+	}
+
+	done := &ddstatsd.Event{
+		Tags:  append(tags, "event_type:shutdown"),
+		Title: fmt.Sprintf("Service Shutdown: %s", serviceName),
+		Text:  fmt.Sprintf("Service '%s @ %s' is stopping", serviceName, version),
+	}
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, os.Interrupt, syscall.SIGTERM, syscall.SIGINT)
+
+	go func() {
+		<-signals
+		_ = client.Event(done)
+	}()
+
+	return nil
+}


### PR DESCRIPTION
We have a few hard to decode events in datadog that make it very hard to understand what is going on. 

There are docker ones:
![image](https://user-images.githubusercontent.com/406376/90575343-0aae4000-e170-11ea-9094-14d597d0c5cf.png)

There are spinnaker ones:
![image](https://user-images.githubusercontent.com/406376/90575325-02ee9b80-e170-11ea-9b01-cb0f51b0e424.png)

This gives us some that are in our common code:
![image](https://user-images.githubusercontent.com/406376/90575313-fd915100-e16f-11ea-9d33-917b19736c5b.png)

Hopefully this can be clearer and we can tweak more easily as we discover wants/needs. 

Things to note:
- pod/hostname is based on a kube env var that I'm checking. Not sure if this is the best way. 
- version/service are from our code
- env/zone/hostname and pretty much all the rest come from the datadog agent. These mostly seem like overkill to me but...I don't think we can get rid of them. 