### PR TITLE
add a LogErrToSpan

### DIFF
--- a/tracing/opentracing.go
+++ b/tracing/opentracing.go
@@ -1,0 +1,24 @@
+package tracing
+
+import (
+	"fmt"
+
+	"github.com/opentracing/opentracing-go"
+	otlog "github.com/opentracing/opentracing-go/log"
+	"github.com/pkg/errors"
+)
+
+type stackTracer interface {
+	StackTrace() errors.StackTrace
+}
+
+func LogErrorToSpan(span opentracing.Span, err error) {
+	if err == nil || span == nil {
+		return
+	}
+
+	span.LogFields(otlog.String("event", "error"), otlog.Error(err))
+	if sterr, ok := err.(stackTracer); ok {
+		span.LogFields(otlog.String("stack", fmt.Sprintf("%+v", sterr.StackTrace())))
+	}
+}


### PR DESCRIPTION
This method is used in a few services and it is pretty useful. I think that it makes sense to import here. Also, anything to make opentracing more usable I'm all for