### PR TITLE
make a global client for feature flagging

### DIFF
--- a/featureflag/global.go
+++ b/featureflag/global.go
@@ -1,0 +1,43 @@
+package featureflag
+
+import (
+	"sync"
+
+	"github.com/sirupsen/logrus"
+)
+
+var globalLock sync.Mutex
+var globalClient Client = MockClient{}
+
+func SetGlobalClient(client Client) {
+	if client == nil {
+		return
+	}
+	globalLock.Lock()
+	globalClient = client
+	globalLock.Unlock()
+}
+
+func GetGlobalClient() Client {
+	globalLock.Lock()
+	defer globalLock.Unlock()
+	return globalClient
+}
+
+// Init will initialize global client with a launch darkly client
+func Init(conf Config, log logrus.FieldLogger) error {
+	ldClient, err := NewClient(&conf, log)
+	if err != nil {
+		return err
+	}
+	SetGlobalClient(ldClient)
+	return nil
+}
+
+func Enabled(key, userID string) bool {
+	return GetGlobalClient().Enabled(key, userID)
+}
+
+func Variation(key, defaultVal, userID string) string {
+	return GetGlobalClient().Variation(key, defaultVal, userID)
+}


### PR DESCRIPTION
I was looking into using this in a service and noticed that it seems like we can use a global one. I am not 100% sure that the underlying launch darkly client is threadsafe, but we had that risk before anyways.

This also ties it into the config defaults