### PR TITLE
make the recoverer tie back to a request

### DIFF
--- a/tracing/context.go
+++ b/tracing/context.go
@@ -30,7 +30,10 @@ func GetTracer(r *http.Request) *RequestTracer {
 }
 
 func GetRequestID(r *http.Request) string {
-	return GetRequestIDFromContext(r.Context())
+	if id := GetRequestIDFromContext(r.Context()); id != "" {
+		return id
+	}
+	return r.Header.Get(HeaderRequestUUID)
 }
 
 func GetRequestIDFromContext(ctx context.Context) string {


### PR DESCRIPTION
When debugging a panic this should introduce the requets that caused it and then a key we can use to sort from because humio messes that up.