### PR TITLE
handle errors better in the tracing and spans

### DIFF
--- a/router/errors_test.go
+++ b/router/errors_test.go
@@ -7,11 +7,18 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
+	"github.com/armon/go-metrics"
+	"github.com/bugsnag/bugsnag-go"
+	"github.com/netlify/netlify-commons/metriks"
 	"github.com/netlify/netlify-commons/tracing"
+	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/mocktracer"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 )
 
 func TestHandleError_ErrorIsNil(t *testing.T) {
@@ -117,4 +124,75 @@ func TestHandleError_ErrorIsNilPointerToTypeOtherError(t *testing.T) {
 
 	require.Len(t, loggerOutput.AllEntries(), 0)
 	assert.Empty(t, w.Header())
+}
+
+func TestHandleError_ErrorGoesToBugsnag(t *testing.T) {
+	var called int
+
+	bugsnag.OnBeforeNotify(func(event *bugsnag.Event, config *bugsnag.Configuration) error {
+		called++
+		require.NotNil(t, event)
+		assert.NotNil(t, event.Ctx)
+
+		assert.NotNil(t, config)
+		return errors.New("this should stop us from sending to bugsnag")
+	})
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	HandleError(errors.New("this is an error"), w, r)
+	assert.Equal(t, 1, called)
+}
+func TestHandleError_ErrorEmitsMetric(t *testing.T) {
+	sink := metrics.NewInmemSink(time.Minute, time.Minute)
+	require.NoError(t, metriks.InitWithSink(t.Name(), sink))
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	HandleError(errors.New("this is an error"), w, r)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+
+	assert.Len(t, sink.Data(), 1)
+}
+func TestHandleError_ErrorFinishesTracer(t *testing.T) {
+	logger, hook := test.NewNullLogger()
+	w, r, _ := tracing.NewTracer(
+		httptest.NewRecorder(),
+		httptest.NewRequest(http.MethodGet, "/", nil),
+		logger,
+		t.Name(),
+	)
+
+	HandleError(errors.New("this is an error"), w, r)
+
+	assert.Len(t, hook.Entries, 2)
+	for _, e := range hook.Entries {
+		switch e.Message {
+		case "Completed Request":
+		case "Unhandled server error: this is an error":
+		default:
+			assert.Fail(t, "unexpected message", e.Message)
+		}
+	}
+}
+
+func TestHandleError_ErrorFinishesSpan(t *testing.T) {
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	mtracer := mocktracer.New()
+	span := mtracer.StartSpan(t.Name())
+	ctx := opentracing.ContextWithSpan(r.Context(), span)
+	r = r.WithContext(ctx)
+	r.Header.Set(tracing.HeaderRequestUUID, "123456")
+
+	HandleError(errors.New("this is an error"), w, r)
+
+	finished := mtracer.FinishedSpans()
+	assert.Len(t, finished, 1)
+
+	tags := finished[0].Tags()
+	assert.Len(t, tags, 3)
+	assert.Equal(t, "123456", tags["error_id"])
+	assert.Equal(t, "this is an error", tags[ext.ErrorMsg])
+	assert.Equal(t, 500, tags[ext.HTTPCode])
 }

--- a/router/middleware.go
+++ b/router/middleware.go
@@ -12,7 +12,9 @@ import (
 
 	"github.com/bugsnag/bugsnag-go"
 	"github.com/netlify/netlify-commons/tracing"
+	"github.com/opentracing/opentracing-go"
 	"github.com/sirupsen/logrus"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 )
 
 var bearerRegexp = regexp.MustCompile(`^(?:B|b)earer (\S+$)`)
@@ -95,6 +97,23 @@ func Recoverer(errLog logrus.FieldLogger) Middleware {
 					Message: http.StatusText(http.StatusInternalServerError),
 				}
 				HandleError(se, w, r)
+
+				// in the event of a panic none of the normal shutdown code is called
+				if span := opentracing.SpanFromContext(r.Context()); span != nil {
+					span.SetTag("error_id", reqID)
+					span.SetTag(ext.ErrorType, "panic")
+					span.SetTag(ext.HTTPCode, http.StatusInternalServerError)
+
+					if err, ok := rvr.(error); ok {
+						span.SetTag(ext.ErrorMsg, err.Error())
+					}
+
+					defer span.Finish()
+				}
+
+				if tr := tracing.GetFromContext(r.Context()); tr != nil {
+					tr.Finish()
+				}
 			}
 		}()
 

--- a/router/middleware.go
+++ b/router/middleware.go
@@ -10,6 +10,7 @@ import (
 	"runtime/debug"
 	"strings"
 
+	"github.com/bugsnag/bugsnag-go"
 	"github.com/netlify/netlify-commons/tracing"
 	"github.com/sirupsen/logrus"
 )
@@ -116,5 +117,13 @@ func HealthCheck(route string, f APIHandler) Middleware {
 			return
 		}
 		next.ServeHTTP(w, r)
+	})
+}
+
+func BugSnag() Middleware {
+	return MiddlewareFunc(func(w http.ResponseWriter, r *http.Request, next http.Handler) {
+		ctx := bugsnag.StartSession(r.Context())
+		defer bugsnag.AutoNotify(ctx)
+		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }

--- a/tracing/req_tracer.go
+++ b/tracing/req_tracer.go
@@ -6,6 +6,7 @@ import (
 
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/sirupsen/logrus"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 )
 
 type RequestTracer struct {
@@ -75,6 +76,7 @@ func (rt *RequestTracer) Finish() {
 	fields["dur"] = dur.String()
 	fields["dur_ns"] = dur.Nanoseconds()
 
+	rt.span.SetTag(ext.HTTPCode, rt.trackingWriter.status)
 	rt.span.Finish()
 	rt.WithFields(fields).Info("Completed Request")
 }


### PR DESCRIPTION
In fighting the cert-store I noticed that when we fall into `HandleError` which is in the case of a panic or unexpected error we don't really cleanup nicely.

This adds that non-nil errors:
- unexpected ones go to bugsnag. This is because returning a 404 isn't an error in and of itself
- we always call `Finish` on the tracing. This is in the event of a panic
- we record unexpected errors in datadog
- we do complete the span if it isn't set