### PR TITLE
fix(kafkaclient): do not close logs channel

### DIFF
--- a/kafka/config.go
+++ b/kafka/config.go
@@ -176,11 +176,7 @@ func WithLogger(log logrus.FieldLogger) ConfigOpt {
 		go func() {
 			// Do not close logsChan because confluent-kafka-go will send logs until we close the client.
 			// Otherwise it will panic trying to send messages to a closed channel.
-			for {
-				m, ok := <-logsChan
-				if !ok {
-					return
-				}
+			for m := range logsChan {
 				l := log.WithFields(logrus.Fields{
 					"kafka_context": m.Tag,
 					"kafka_client":  m.Name,

--- a/kafka/config.go
+++ b/kafka/config.go
@@ -175,7 +175,8 @@ func WithLogger(ctx context.Context, log logrus.FieldLogger) ConfigOpt {
 
 		// Read from channel and print logs using the provided logger.
 		go func() {
-			defer close(logsChan)
+			// Do not close logsChan because confluent-kafka-go will send logs until we close the client.
+			// Otherwise it will panic trying to send messages to a closed channel.
 			for {
 				select {
 				case <-ctx.Done():

--- a/kafka/integration_test.go
+++ b/kafka/integration_test.go
@@ -50,7 +50,7 @@ func TestIntegration(t *testing.T) {
 		}
 
 		// create the producer
-		p, err := NewProducer(conf, WithLogger(ctx, log), WithPartitionerAlgorithm(PartitionerMurMur2))
+		p, err := NewProducer(conf, WithLogger(log), WithPartitionerAlgorithm(PartitionerMurMur2))
 		assert.NoError(err)
 		assert.NotNil(p)
 
@@ -131,7 +131,7 @@ func TestIntegration(t *testing.T) {
 		val := "gotestval"
 
 		// create the producer
-		p, err := NewProducer(conf, WithLogger(ctx, log), WithPartitionerAlgorithm(PartitionerMurMur2))
+		p, err := NewProducer(conf, WithLogger(log), WithPartitionerAlgorithm(PartitionerMurMur2))
 		assert.NoError(err)
 		assert.NotNil(p)
 


### PR DESCRIPTION
Logs channel was closed when the context got canceled. This ends in a race condition where the `confluent-kafka-go` library tries to still send log messages (client not closed yet) to a closed channel, producing a  panic: `panic: send on closed channel`