### PR TITLE
Return dummy featureflag client on error

### DIFF
--- a/featureflag/featureflag.go
+++ b/featureflag/featureflag.go
@@ -37,10 +37,8 @@ func NewClient(cfg *Config, logger logrus.FieldLogger) (Client, error) {
 	inner, err := ld.MakeCustomClient(cfg.Key, config, cfg.RequestTimeout)
 	if err != nil {
 		logger.WithError(err).Error("Unable to construct LD client")
-		return nil, err
 	}
-
-	return &ldClient{inner, logger}, nil
+	return &ldClient{inner, logger}, err
 }
 
 func (c *ldClient) Enabled(key string, userID string) bool {


### PR DESCRIPTION
We had some panics in Buildbot from https://github.com/netlify/buildbot/pull/915 because Buildbot expects the client to present even when it isn't successfully initiated.

When that's the case, it will return `false` for flags, eg https://godoc.org/gopkg.in/launchdarkly/go-client.v4#LDClient.BoolVariation
> BoolVariation returns the value of a boolean feature flag for a given user. Returns defaultVal if there is an error, if the flag doesn't exist, the client hasn't completed initialization, or the feature is turned off and has no off variation. 

Proceeding with flags set to false seems preferable to failing the build, and returning the client alongside an error lets consumers of this package decide if they want to proceed or not.