### PR TITLE
chore(ci): improve Docker Compose files for a more robust experience running integration tests

### DIFF
--- a/Dockercompose.test.yml
+++ b/Dockercompose.test.yml
@@ -1,116 +1,77 @@
 ---
-version: '2'
+version: '3'
+
 services:
-  zookeeper-1:
+  zookeeper:
     image: confluentinc/cp-zookeeper:latest
     environment:
-      ZOOKEEPER_SERVER_ID: 1
       ZOOKEEPER_CLIENT_PORT: 22181
-      ZOOKEEPER_TICK_TIME: 2000
-      ZOOKEEPER_INIT_LIMIT: 5
-      ZOOKEEPER_SYNC_LIMIT: 2
-      ZOOKEEPER_SERVERS: localhost:22888:23888;localhost:32888:33888;localhost:42888:43888
-    network_mode: host
-    extra_hosts:
-      - "moby:127.0.0.1"
-    logging:
-      driver: none # change this to json-file if you want to debug kafka
-
-  zookeeper-2:
-    image: confluentinc/cp-zookeeper:latest
-    environment:
-      ZOOKEEPER_SERVER_ID: 2
-      ZOOKEEPER_CLIENT_PORT: 32181
-      ZOOKEEPER_TICK_TIME: 2000
-      ZOOKEEPER_INIT_LIMIT: 5
-      ZOOKEEPER_SYNC_LIMIT: 2
-      ZOOKEEPER_SERVERS: localhost:22888:23888;localhost:32888:33888;localhost:42888:43888
-    network_mode: host
-    extra_hosts:
-      - "moby:127.0.0.1"
-    logging:
-      driver: none # change this to json-file if you want to debug kafka
-
-  zookeeper-3:
-    image: confluentinc/cp-zookeeper:latest
-    environment:
-      ZOOKEEPER_SERVER_ID: 3
-      ZOOKEEPER_CLIENT_PORT: 42181
-      ZOOKEEPER_TICK_TIME: 2000
-      ZOOKEEPER_INIT_LIMIT: 5
-      ZOOKEEPER_SYNC_LIMIT: 2
-      ZOOKEEPER_SERVERS: localhost:22888:23888;localhost:32888:33888;localhost:42888:43888
-    network_mode: host
-    extra_hosts:
-      - "moby:127.0.0.1"
+    ports:
+      - 22181:22181
     logging:
       driver: none # change this to json-file if you want to debug kafka
 
   kafka-1:
     image: confluentinc/cp-kafka:latest
-    network_mode: host
+    hostname: kafka-1
     depends_on:
-      - zookeeper-1
-      - zookeeper-2
-      - zookeeper-3
+      - zookeeper
     environment:
       KAFKA_BROKER_ID: 1
-      KAFKA_ZOOKEEPER_CONNECT: localhost:22181,localhost:32181,localhost:42181
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:19092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:22181
+      KAFKA_ADVERTISED_LISTENERS:  PLAINTEXT://kafka-1:19092,PLAINTEXT_HOST://localhost:19093
       KAFKA_CONFLUENT_SUPPORT_METRICS_ENABLE: "false"
-    extra_hosts:
-      - "moby:127.0.0.1"
+    ports:
+      - 19093:19093 # From outside docker network
     logging:
       driver: none # change this to json-file if you want to debug kafka
 
   kafka-2:
     image: confluentinc/cp-kafka:latest
-    network_mode: host
+    hostname: kafka-2
     depends_on:
-      - zookeeper-1
-      - zookeeper-2
-      - zookeeper-3
+      - zookeeper
     environment:
       KAFKA_BROKER_ID: 2
-      KAFKA_ZOOKEEPER_CONNECT: localhost:22181,localhost:32181,localhost:42181
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:29092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:22181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka-2:29092,PLAINTEXT_HOST://localhost:29093
       KAFKA_CONFLUENT_SUPPORT_METRICS_ENABLE: "false"
-    extra_hosts:
-      - "moby:127.0.0.1"
+    ports:
+      - 29092:29092
+      - 29093:29093 # From outside docker network
     logging:
-      driver: none  # change this to json-file if you want to debug kafka
+      driver: none # change this to json-file if you want to debug kafka
 
   kafka-3:
     image: confluentinc/cp-kafka:latest
-    network_mode: host
+    hostname: kafka-3
     depends_on:
-      - zookeeper-1
-      - zookeeper-2
-      - zookeeper-3
+      - zookeeper
     environment:
       KAFKA_BROKER_ID: 3
-      KAFKA_ZOOKEEPER_CONNECT: localhost:22181,localhost:32181,localhost:42181
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:39092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:22181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka-3:39092,PLAINTEXT_HOST://localhost:39093
       KAFKA_CONFLUENT_SUPPORT_METRICS_ENABLE: "false"
-    extra_hosts:
-      - "moby:127.0.0.1"
+    ports:
+      - 39092:39092
+      - 39093:39093 # From outside docker network
     logging:
-      driver: none  # change this to json-file if you want to debug kafka
+      driver: none # change this to json-file if you want to debug kafka
 
   kafka_setup:
     build:
       context: .
       dockerfile: Dockerfile.setup
     depends_on:
-      - zookeeper-1
-      - zookeeper-2
-      - zookeeper-3
+      - zookeeper
       - kafka-1
       - kafka-2
       - kafka-3
-    network_mode: host
     logging:
-      driver: none  # change this to json-file if you want to debug kafka setup
+      driver: none # change this to json-file if you want to debug kafka setup
 
   golang_tests:
     build:
@@ -118,6 +79,5 @@ services:
       dockerfile: Dockerfile.test
     depends_on:
       - kafka_setup
-    network_mode: host
     environment:
-      KAFKA_TEST_BROKERS: localhost:19092,localhost:29092,localhost:39092
+      KAFKA_TEST_BROKERS: kafka-1:19092,kafka-2:29092,kafka-3:39092

--- a/Dockerfile.setup
+++ b/Dockerfile.setup
@@ -1,4 +1,4 @@
 FROM confluentinc/cp-kafka
 
 # Create the Kafka Topic & sleep forever
-CMD bash -c "kafka-topics --delete --bootstrap-server kafka-1:19092 --topic integrationtest || true && sleep 1 && kafka-topics --create --bootstrap-server kafka-1:19092 --replication-factor 1 --partitions 3 --topic integrationtest && sleep infinity"
+CMD bash -c "kafka-topics --delete --bootstrap-server kafka-1:19092 --topic gotest || true && sleep 1 && kafka-topics --create --bootstrap-server kafka-1:19092 --replication-factor 1 --partitions 3 --topic gotest && sleep infinity"

--- a/Dockerfile.setup
+++ b/Dockerfile.setup
@@ -1,4 +1,4 @@
 FROM confluentinc/cp-kafka
 
 # Create the Kafka Topic & sleep forever
-CMD kafka-topics --create --bootstrap-server localhost:19092 --replication-factor 1 --partitions 3 --topic gotest && sleep infinity
+CMD bash -c "kafka-topics --delete --bootstrap-server kafka-1:19092 --topic integrationtest || true && sleep 1 && kafka-topics --create --bootstrap-server kafka-1:19092 --replication-factor 1 --partitions 3 --topic integrationtest && sleep infinity"

--- a/kafka/consume.go
+++ b/kafka/consume.go
@@ -128,7 +128,7 @@ func NewDetachedConsumer(log logrus.FieldLogger, conf Config, opts ...ConfigOpt)
 // NewConsumer creates a ConfluentConsumer based on config.
 // - NOTE if the partition is set and the partition key is not set in config we have no way
 //   of knowing where to assign the consumer to in the case of a rebalance
-func NewConsumer(log logrus.FieldLogger, conf Config, opts ...ConfigOpt) (Consumer, error) {
+func NewConsumer(log logrus.FieldLogger, conf Config, opts ...ConfigOpt) (*ConfluentConsumer, error) {
 	// See Reference at https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md
 	kafkaConf := conf.baseKafkaConfig()
 	_ = kafkaConf.SetKey("enable.auto.offset.store", false) // manually StoreOffset after processing a message. Otherwise races may happen.)
@@ -173,7 +173,7 @@ func NewConsumer(log logrus.FieldLogger, conf Config, opts ...ConfigOpt) (Consum
 		}
 
 		logFields["kafka_partition_key"] = cc.conf.Consumer.PartitionKey
-		logFields["kafka_partition"] = cc.conf.Consumer.Partition
+		logFields["kafka_partition"] = *cc.conf.Consumer.Partition
 	}
 
 	cc.setupRebalanceHandler()

--- a/kafka/consume.go
+++ b/kafka/consume.go
@@ -62,7 +62,7 @@ type ConfluentConsumer struct {
 //       permission on the group coordinator for managing commits, so it needs a consumer group in the broker.
 //       In order to simplify, the default consumer group id is copied from the configured topic name, so make sure you have a
 //       policy that gives permission to such consumer group.
-func NewDetachedConsumer(log logrus.FieldLogger, conf Config, opts ...ConfigOpt) (Consumer, error) {
+func NewDetachedConsumer(log logrus.FieldLogger, conf Config, opts ...ConfigOpt) (*ConfluentConsumer, error) {
 	// See Reference at https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md
 	kafkaConf := conf.baseKafkaConfig()
 	_ = kafkaConf.SetKey("enable.auto.offset.store", false) // manually StoreOffset after processing a message. It is mandatory for detached consumers.

--- a/kafka/consume_test.go
+++ b/kafka/consume_test.go
@@ -38,5 +38,5 @@ func consumer(t *testing.T) (*ConfluentConsumer, Config) {
 	c, err := NewConsumer(logger(), conf)
 	require.NoError(t, err)
 
-	return c.(*ConfluentConsumer), conf
+	return c, conf
 }


### PR DESCRIPTION
Integration tests run on Docker via Docker Compose.
There was some issues on the configuration, on how we were creating the kafka topic for testing the `kafka` package, and some other minors (including using version 2 which is outdated).

This PR fixes all known issues and updates the Docker Compose file but also simplifies the configuration for Kafka (only need 1 zookeeper vs 3, removing host-network mode, etc).

It also fixes the integration test.