### PR TITLE
Proactively trim dangling comma's from AID values

### DIFF
--- a/parser/user_traffic.go
+++ b/parser/user_traffic.go
@@ -101,12 +101,15 @@ func ParseUserTrafficRecord(raw string) (*UserTraffic, error) {
 		case "url":
 			ut.URL = parts[1]
 		case "sid":
-			//SID's somewhat frequently have a trailing comma, while we try not to manipulate
+			//SID's & AID's somewhat frequently have a trailing comma, while we try not to manipulate
 			//or clean up the log lines inline this was an easy one that we felt we should
 			//proactively handle
 			ut.SID = strings.TrimSuffix(parts[1], ",")
 		case "aid":
-			ut.AID = parts[1]
+			//SID's & AID's somewhat frequently have a trailing comma, while we try not to manipulate
+			//or clean up the log lines inline this was an easy one that we felt we should
+			//proactively handle
+			ut.AID = strings.TrimSuffix(parts[1], ",")
 		case "did":
 			ut.DID = parts[1]
 		case "cancel":

--- a/parser/user_traffic_test.go
+++ b/parser/user_traffic_test.go
@@ -189,6 +189,14 @@ func TestSidWithComma(t *testing.T) {
 	assert.Equal(t, sidField, ut.SID)
 }
 
+func TestAidWithComma(t *testing.T) {
+	fields := defaultValues()
+	fields["aidField"] = fields["aidField"] + ","
+	ut, err := ParseUserTrafficRecord(genUserTrafficLine(t, fields))
+	require.NoError(t, err)
+	assert.Equal(t, sidField, ut.SID)
+}
+
 func TestErrOnExtraTimestamp(t *testing.T) {
 	withExtraTimestamp := "@timestamp=181818181 " + genUserTrafficLine(t, defaultValues())
 	ut, err := ParseUserTrafficRecord(withExtraTimestamp)


### PR DESCRIPTION
AID's have dangling comma's at a lower frequency than SID's but happens enough that its still pretty disruptive and worth proactively fixing. 