### PR TITLE
Add method to get all enabled feature flags for a user

### DIFF
--- a/featureflag/config.go
+++ b/featureflag/config.go
@@ -1,9 +1,14 @@
 package featureflag
 
-import "time"
+import (
+	"time"
+
+	ld "gopkg.in/launchdarkly/go-server-sdk.v4"
+)
 
 type Config struct {
-	Key            string
-	RequestTimeout time.Duration `mapstructure:"request_timeout" split_words:"true" default:"5s"`
-	Enabled        bool          `default:"false"`
+	Key                    string
+	RequestTimeout         time.Duration `mapstructure:"request_timeout" split_words:"true" default:"5s"`
+	Enabled                bool          `default:"false"`
+	updateProcessorFactory ld.UpdateProcessorFactory
 }

--- a/featureflag/featureflag.go
+++ b/featureflag/featureflag.go
@@ -67,10 +67,11 @@ func (c *ldClient) VariationUser(key string, defaultVal string, user ld.User) st
 
 func (c *ldClient) AllEnabledFlags(userId string) []string {
 	// Ask launch darkly for all the flags for the user, return ld.FeatureFlagsState
-	// getEnabledFlags()
+	res := c.AllFlagsState(ld.NewUser(userId), ld.DetailsOnlyForTrackedFlags)
+	return getEnabledFromState(res)
 }
 
-func getEnabledFlagsFromState(ffState ld.FeatureFlagsState) []string {
+func getEnabledFromState(ffState ld.FeatureFlagsState) []string {
 
 }
 

--- a/featureflag/featureflag.go
+++ b/featureflag/featureflag.go
@@ -2,7 +2,6 @@ package featureflag
 
 import (
 	"io/ioutil"
-	"log"
 
 	"github.com/sirupsen/logrus"
 
@@ -75,7 +74,10 @@ func (c *ldClient) VariationUser(key string, defaultVal string, user ld.User) st
 func (c *ldClient) AllEnabledFlags(userId string) []string {
 	// Ask launch darkly for all the flags for the user, return ld.FeatureFlagsState
 	res := c.AllFlagsState(ld.NewUser(userId), ld.DetailsOnlyForTrackedFlags)
-	log.Println(res)
+	flagMap := res.ToValuesMap()
+	for key, value := range flagMap {
+		// get the "true" flags
+	}
 	return []string{}
 }
 

--- a/featureflag/featureflag.go
+++ b/featureflag/featureflag.go
@@ -34,6 +34,7 @@ func NewClient(cfg *Config, logger logrus.FieldLogger) (Client, error) {
 
 	if cfg.updateProcessorFactory != nil {
 		config.UpdateProcessorFactory = cfg.updateProcessorFactory
+		config.SendEvents = false
 	}
 
 	if logger == nil {
@@ -72,7 +73,6 @@ func (c *ldClient) VariationUser(key string, defaultVal string, user ld.User) st
 }
 
 func (c *ldClient) AllEnabledFlags(userId string) []string {
-	// Ask launch darkly for all the flags for the user, return ld.FeatureFlagsState
 	res := c.AllFlagsState(ld.NewUser(userId), ld.DetailsOnlyForTrackedFlags)
 	flagMap := res.ToValuesMap()
 	for key, value := range flagMap {

--- a/featureflag/featureflag.go
+++ b/featureflag/featureflag.go
@@ -15,7 +15,7 @@ type Client interface {
 	Variation(key, defaultVal, userID string) string
 	VariationUser(key string, defaultVal string, user ld.User) string
 
-	AllEnabledFlags(userID string) []string
+	AllEnabledFlags(key string) []string
 }
 
 type ldClient struct {
@@ -72,8 +72,8 @@ func (c *ldClient) VariationUser(key string, defaultVal string, user ld.User) st
 	return res
 }
 
-func (c *ldClient) AllEnabledFlags(userId string) []string {
-	res := c.AllFlagsState(ld.NewUser(userId), ld.DetailsOnlyForTrackedFlags)
+func (c *ldClient) AllEnabledFlags(key string) []string {
+	res := c.AllFlagsState(ld.NewUser(key), ld.DetailsOnlyForTrackedFlags)
 	flagMap := res.ToValuesMap()
 
 	var flags []string

--- a/featureflag/featureflag.go
+++ b/featureflag/featureflag.go
@@ -2,6 +2,7 @@ package featureflag
 
 import (
 	"io/ioutil"
+	"log"
 
 	"github.com/sirupsen/logrus"
 
@@ -14,6 +15,8 @@ type Client interface {
 
 	Variation(key, defaultVal, userID string) string
 	VariationUser(key string, defaultVal string, user ld.User) string
+
+	AllEnabledFlags(userID string) []string
 }
 
 type ldClient struct {
@@ -28,6 +31,10 @@ func NewClient(cfg *Config, logger logrus.FieldLogger) (Client, error) {
 
 	if !cfg.Enabled {
 		config.Offline = true
+	}
+
+	if cfg.updateProcessorFactory != nil {
+		config.UpdateProcessorFactory = cfg.updateProcessorFactory
 	}
 
 	if logger == nil {
@@ -68,11 +75,8 @@ func (c *ldClient) VariationUser(key string, defaultVal string, user ld.User) st
 func (c *ldClient) AllEnabledFlags(userId string) []string {
 	// Ask launch darkly for all the flags for the user, return ld.FeatureFlagsState
 	res := c.AllFlagsState(ld.NewUser(userId), ld.DetailsOnlyForTrackedFlags)
-	return getEnabledFromState(res)
-}
-
-func getEnabledFromState(ffState ld.FeatureFlagsState) []string {
-
+	log.Println(res)
+	return []string{}
 }
 
 func noopLogger() *logrus.Logger {

--- a/featureflag/featureflag.go
+++ b/featureflag/featureflag.go
@@ -65,6 +65,15 @@ func (c *ldClient) VariationUser(key string, defaultVal string, user ld.User) st
 	return res
 }
 
+func (c *ldClient) AllEnabledFlags(userId string) []string {
+	// Ask launch darkly for all the flags for the user, return ld.FeatureFlagsState
+	// getEnabledFlags()
+}
+
+func getEnabledFlagsFromState(ffState ld.FeatureFlagsState) []string {
+
+}
+
 func noopLogger() *logrus.Logger {
 	l := logrus.New()
 	l.SetOutput(ioutil.Discard)

--- a/featureflag/featureflag.go
+++ b/featureflag/featureflag.go
@@ -75,10 +75,18 @@ func (c *ldClient) VariationUser(key string, defaultVal string, user ld.User) st
 func (c *ldClient) AllEnabledFlags(userId string) []string {
 	res := c.AllFlagsState(ld.NewUser(userId), ld.DetailsOnlyForTrackedFlags)
 	flagMap := res.ToValuesMap()
-	for key, value := range flagMap {
-		// get the "true" flags
+
+	var flags []string
+	for flag, value := range flagMap {
+		switch value.(type) {
+		case bool:
+			if value == true {
+				flags = append(flags, flag)
+			}
+		}
 	}
-	return []string{}
+
+	return flags
 }
 
 func noopLogger() *logrus.Logger {

--- a/featureflag/featureflag_test.go
+++ b/featureflag/featureflag_test.go
@@ -40,6 +40,6 @@ func TestMockClient(t *testing.T) {
 	require.Equal(t, "DFLT", mock.Variation("FOOBAR", "DFLT", "12345"))
 }
 
-func TestGetEnabledFlagsFromState(t *testing.T) {
+func TestGetEnabledFromState(t *testing.T) {
 
 }

--- a/featureflag/featureflag_test.go
+++ b/featureflag/featureflag_test.go
@@ -52,5 +52,7 @@ func TestAllEnabledFlags(t *testing.T) {
 	client, err := NewClient(&cfg, nil)
 	require.NoError(t, err)
 
-	client.AllEnabledFlags("userid")
+	flags := client.AllEnabledFlags("userid")
+
+	require.Equal(t, []string{"my-boolean-flag-key"}, flags)
 }

--- a/featureflag/featureflag_test.go
+++ b/featureflag/featureflag_test.go
@@ -52,5 +52,5 @@ func TestAllEnabledFlags(t *testing.T) {
 	client, err := NewClient(&cfg, nil)
 	require.NoError(t, err)
 
-	client.AllEnabledFlags("foo")
+	client.AllEnabledFlags("userid")
 }

--- a/featureflag/featureflag_test.go
+++ b/featureflag/featureflag_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"gopkg.in/launchdarkly/go-server-sdk.v4/ldfiledata"
 )
 
 func TestOfflineClient(t *testing.T) {
@@ -40,6 +41,16 @@ func TestMockClient(t *testing.T) {
 	require.Equal(t, "DFLT", mock.Variation("FOOBAR", "DFLT", "12345"))
 }
 
-func TestGetEnabledFromState(t *testing.T) {
+func TestAllEnabledFlags(t *testing.T) {
+	fileSource := ldfiledata.NewFileDataSourceFactory(ldfiledata.FilePaths("./fixtures/flags.yml"))
+	cfg := Config{
+		Key:                    "ABCD",
+		RequestTimeout:         time.Second,
+		Enabled:                true,
+		updateProcessorFactory: fileSource,
+	}
+	client, err := NewClient(&cfg, nil)
+	require.NoError(t, err)
 
+	client.AllEnabledFlags("foo")
 }

--- a/featureflag/featureflag_test.go
+++ b/featureflag/featureflag_test.go
@@ -39,3 +39,7 @@ func TestMockClient(t *testing.T) {
 	require.Equal(t, "BAR", mock.Variation("FOO", "DFLT", "12345"))
 	require.Equal(t, "DFLT", mock.Variation("FOOBAR", "DFLT", "12345"))
 }
+
+func TestGetEnabledFlagsFromState(t *testing.T) {
+
+}

--- a/featureflag/fixtures/flags.yml
+++ b/featureflag/fixtures/flags.yml
@@ -1,4 +1,5 @@
 flagValues:
   my-string-flag-key: "value-1"
   my-boolean-flag-key: true
+  my-boolean-off-flag-key: false
   my-integer-flag-key: 3

--- a/featureflag/fixtures/flags.yml
+++ b/featureflag/fixtures/flags.yml
@@ -1,0 +1,4 @@
+flagValues:
+  my-string-flag-key: "value-1"
+  my-boolean-flag-key: true
+  my-integer-flag-key: 3

--- a/featureflag/mock.go
+++ b/featureflag/mock.go
@@ -1,6 +1,8 @@
 package featureflag
 
-import ld "gopkg.in/launchdarkly/go-server-sdk.v4"
+import (
+	ld "gopkg.in/launchdarkly/go-server-sdk.v4"
+)
 
 type MockClient struct {
 	BoolVars   map[string]bool
@@ -27,4 +29,8 @@ func (c MockClient) VariationUser(key string, defaultVal string, _ ld.User) stri
 		return defaultVal
 	}
 	return res
+}
+
+func (c MockClient) AllEnabledFlags(string) []string {
+	return []string{}
 }

--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,7 @@ require (
 	golang.org/x/net v0.0.0-20200813134508-3edf25e44fcc
 	gopkg.in/DataDog/dd-trace-go.v1 v1.26.0
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
+	gopkg.in/ghodss/yaml.v1 v1.0.0 // indirect
 	gopkg.in/launchdarkly/go-sdk-common.v1 v1.0.0-20200401173443-991b2f427a01 // indirect
 	gopkg.in/launchdarkly/go-server-sdk.v4 v4.0.0-20200729232655-2a44fb361895
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776

--- a/go.sum
+++ b/go.sum
@@ -558,6 +558,8 @@ gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
+gopkg.in/ghodss/yaml.v1 v1.0.0 h1:JlY4R6oVz+ZSvcDhVfNQ/k/8Xo6yb2s1PBhslPZPX4c=
+gopkg.in/ghodss/yaml.v1 v1.0.0/go.mod h1:HDvRMPQLqycKPs9nWLuzZWxsxRzISLCRORiDpBUOMqg=
 gopkg.in/ini.v1 v1.51.0 h1:AQvPpx3LzTDM0AjnIRlVFwFFGC+npRopjZxLJj6gdno=
 gopkg.in/ini.v1 v1.51.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/launchdarkly/go-sdk-common.v1 v1.0.0-20200204015611-d48d1b4f4e70/go.mod h1:2kE5FCTDQ53bqRSOfJpE5fdiAQYiN9LESONDNyEBFjI=


### PR DESCRIPTION
In buildbot, we want to start passing feature flags down to netlify build. To do so, we need a method to get all enabled flags for a user. For this particular case, we only care about boolean ones.

This adds a method to the featureflag package to do so. LanuchDarkly's Go SDK provides a way to get all flags for a user, so we wrap that in another method to select just the enabled boolean ones.

For tests, it uses the file config as suggested by LaunchDarkly docs: https://docs.launchdarkly.com/sdk/concepts/flags-from-files