### PR TITLE
Make featureflag.MockClient return enabled flags in AllEnabledFlags

### DIFF
--- a/featureflag/mock.go
+++ b/featureflag/mock.go
@@ -32,5 +32,11 @@ func (c MockClient) VariationUser(key string, defaultVal string, _ ld.User) stri
 }
 
 func (c MockClient) AllEnabledFlags(string) []string {
-	return []string{}
+	var res []string
+	for key, value := range c.BoolVars {
+		if value {
+			res = append(res, key)
+		}
+	}
+	return res
 }


### PR DESCRIPTION
Followup to https://github.com/netlify/netlify-commons/pull/187

The MockClient should respect the flags set for it.