### PR TITLE
feat(kafka): add ConsumerFactory in order to align future developments

### DIFF
--- a/kafka/consume_test.go
+++ b/kafka/consume_test.go
@@ -22,11 +22,11 @@ func TestConsumerFetchMessageContextAwareness(t *testing.T) {
 func TestConsumerSeek(t *testing.T) {
 	c, conf := consumer(t)
 	defer checkClose(t, c)
-	require.NoError(t, c.c.Assign(kafkalib.TopicPartitions{{Topic: &conf.Topic, Partition: 0}})) // manually assign partition
+	require.NoError(t, c.(*ConfluentConsumer).c.Assign(kafkalib.TopicPartitions{{Topic: &conf.Topic, Partition: 0}})) // manually assign partition
 	require.NoError(t, c.Seek(2))
 }
 
-func consumer(t *testing.T) (*ConfluentConsumer, Config) {
+func consumer(t *testing.T) (Consumer, Config) {
 	conf := Config{
 		Brokers: nil, // No brokers are used for unit test.
 		Topic:   "gotest",

--- a/kafka/kafkatest/utils.go
+++ b/kafka/kafkatest/utils.go
@@ -12,6 +12,18 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+func FakeKafkaConsumerFactory(distri <-chan *kafkalib.Message) kafka.ConsumerFactory {
+	return func(log logrus.FieldLogger, _ kafka.Config, _ ...kafka.ConfigOpt) (kafka.Consumer, error) {
+		return NewFakeKafkaConsumer(log, distri), nil
+	}
+}
+
+func KafkaConsumerFactoryFromConsumer(c kafka.Consumer) kafka.ConsumerFactory {
+	return func(_ logrus.FieldLogger, _ kafka.Config, _ ...kafka.ConfigOpt) (kafka.Consumer, error) {
+		return c, nil
+	}
+}
+
 func KafkaPipe(log logrus.FieldLogger) (*FakeKafkaConsumer, *FakeKafkaProducer) {
 	distri := make(chan *kafkalib.Message, 200)
 	rdr := NewFakeKafkaConsumer(log, distri)


### PR DESCRIPTION
In an effort to help users of our Kafka lib with common use cases, this PR adds a Factory function type, which can be used for postponing the creation of a consumer on runtime. E.g. setting an initial offset that you don't know on boot time.

`NewConsumer` and `NewDetachedConsumer` implements this already.