### PR TITLE
feat(kafka): add test for FakeKafkaProducer WaitForKey

### DIFF
--- a/kafka/kafkatest/utils_test.go
+++ b/kafka/kafkatest/utils_test.go
@@ -1,0 +1,31 @@
+package kafkatest
+
+import (
+	"context"
+	"testing"
+
+	kafkalib "github.com/confluentinc/confluent-kafka-go/kafka"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFakeKafkaProducer_WaitForKey(t *testing.T) {
+	log := logrus.New()
+	c, p := KafkaPipe(log)
+	defer p.Close()
+	defer c.Close()
+
+	key := []byte(`key`)
+	val := []byte(`foobar`)
+	err := p.Produce(context.Background(), &kafkalib.Message{
+		Value: val,
+		Key:   key,
+	})
+	msg, err := c.FetchMessage(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, key, msg.Key)
+	require.Equal(t, val, msg.Value)
+
+	require.NoError(t, c.CommitMessage(msg))
+	require.True(t, p.WaitForKey(key))
+}


### PR DESCRIPTION
This PR adds a simple test around the `WaitForKey` method on the FakeKafkaProducer, located in the `kafkatest` kafka subpackage.
The purpose is valid also to simply show how you can use Pipes and wait for messages to be committed without having to use `time.Sleep` or similar techniques.

cc @aarushik93 