### PR TITLE
Support local LD relay and disable telemetry.

### DIFF
--- a/featureflag/config.go
+++ b/featureflag/config.go
@@ -11,4 +11,10 @@ type Config struct {
 	RequestTimeout         time.Duration `mapstructure:"request_timeout" split_words:"true" default:"5s"`
 	Enabled                bool          `default:"false"`
 	updateProcessorFactory ld.UpdateProcessorFactory
+
+	// Drop telemetry events (not needed in local-dev/CI environments)
+	DisableEvents bool `mapstructure:"disable_events" split_words:"true"`
+
+	// Set when using the Launch Darkly Relay proxy
+	RelayHost string `mapstructure:"relay_host" split_words:"true"`
 }

--- a/featureflag/featureflag.go
+++ b/featureflag/featureflag.go
@@ -41,6 +41,16 @@ func NewClient(cfg *Config, logger logrus.FieldLogger) (Client, error) {
 		logger = noopLogger()
 	}
 
+	if cfg.RelayHost != "" {
+		config.BaseUri = cfg.RelayHost
+		config.StreamUri = cfg.RelayHost
+		config.EventsUri = cfg.RelayHost
+	}
+
+	if cfg.DisableEvents {
+		config.SendEvents = false
+	}
+
 	inner, err := ld.MakeCustomClient(cfg.Key, config, cfg.RequestTimeout)
 	if err != nil {
 		logger.WithError(err).Error("Unable to construct LD client")


### PR DESCRIPTION
Support the LaunchDarkly [relay](https://github.com/launchdarkly/ld-relay) proxy for continuous integration scenarios where you need to flip flags on/off during test runs and ensure propagation. Also allow the telemetry features to be disabled in these scenarios, as they don't work with the relay proxy.