### PR TITLE
Add regex based kv extraction option

### DIFF
--- a/parser/user_traffic.go
+++ b/parser/user_traffic.go
@@ -2,64 +2,49 @@ package parser
 
 import (
 	"fmt"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
 )
 
-var (
-	// regex to try and extract key=value entries
-	re = regexp.MustCompile(`(?m)(\w+)=([^\s]+)`)
-)
-
 //UserTraffic is a single decoded user traffic log line
 type UserTraffic struct {
-	Status       int               `json:"status"`
-	RequestSize  int64             `json:"request_size"`
-	ResponseSize int64             `json:"response_size"`
-	Timing       int64             `json:"timing"`
-	Timestamp    time.Time         `json:"timestamp"`
-	RequestID    string            `json:"request_id"`
-	Result       string            `json:"result"`
-	CSID         string            `json:"csid"`
-	CCID         string            `jsond:"ccid"`
-	CID          string            `json:"cid"`
-	Proto        string            `json:"proto"`
-	Method       string            `json:"method"`
-	URL          string            `json:"url"`
-	SID          string            `json:"sid"`
-	AID          string            `json:"aid"`
-	DID          string            `json:"did"`
-	Cancel       string            `json:"cancel"`
-	CCancel      string            `json:"ccancel"`
-	ProxyType    string            `json:"proxy_type"`
-	FID          string            `json:"fid"`
-	ContentType  string            `json:"content_type"`
-	Address      string            `json:"address"`
-	Country      string            `json:"country"`
-	Referrer     string            `json:"referrer"`
-	CW           string            `json:"cw"`
-	SSLVersion   string            `json:"ssl_version"`
-	SSLCipher    string            `json:"ssl_cipher"`
-	ENC          string            `json:"enc"`
-	UserAgent    string            `json:"ua"`
-	Other        map[string]string `json:"other"`
-}
-
-func extractPair(s string, useRegex bool) []string {
-	if useRegex {
-		return re.FindAllString(s, -1)
-	}
-	return strings.Fields(s)
+	Status       int       `json:"status"`
+	RequestSize  int64     `json:"request_size"`
+	ResponseSize int64     `json:"response_size"`
+	Timing       int64     `json:"timing"`
+	Timestamp    time.Time `json:"timestamp"`
+	RequestID    string    `json:"request_id"`
+	Result       string    `json:"result"`
+	CSID         string    `json:"csid"`
+	CCID         string    `jsond:"ccid"`
+	CID          string    `json:"cid"`
+	Proto        string    `json:"proto"`
+	Method       string    `json:"method"`
+	URL          string    `json:"url"`
+	SID          string    `json:"sid"`
+	AID          string    `json:"aid"`
+	DID          string    `json:"did"`
+	Cancel       string    `json:"cancel"`
+	CCancel      string    `json:"ccancel"`
+	ProxyType    string    `json:"proxy_type"`
+	FID          string    `json:"fid"`
+	ContentType  string    `json:"content_type"`
+	Address      string    `json:"address"`
+	Country      string    `json:"country"`
+	Referrer     string    `json:"referrer"`
+	CW           string    `json:"cw"`
+	SSLVersion   string    `json:"ssl_version"`
+	SSLCipher    string    `json:"ssl_cipher"`
+	ENC          string    `json:"enc"`
+	UserAgent    string    `json:"ua"`
+	Unparsed     []string  `json:"unparsed"`
 }
 
 //ParseUserTrafficRecord parses a raw user traffic log line into a UserTraffic struct
-//opting to use the regex extractor will cause the parser to use a regex expression to
-//select underlying k=v value fields rather than using string splitting. The regex based
-//parser is a bit more forgiving in that it's less likely to select dangling value field
-//entries as key's.
-func ParseUserTrafficRecord(raw string, useRegexExtractor bool) (*UserTraffic, error) {
+//A slice of any unknown kv pairs or unbalanced fields will be appended to the UserTraffic
+//structs Unparsed field.
+func ParseUserTrafficRecord(raw string) (*UserTraffic, error) {
 	var ut UserTraffic
 	var err error
 
@@ -73,10 +58,11 @@ func ParseUserTrafficRecord(raw string, useRegexExtractor bool) (*UserTraffic, e
 		ut.UserAgent = praw[1]
 	}
 
-	for _, field := range extractPair(praw[0], useRegexExtractor) {
+	for _, field := range strings.Fields(praw[0]) {
 		parts := strings.SplitN(field, "=", 2)
-		if len(parts) != 2 {
-			return nil, fmt.Errorf("found key field with no value: %s", parts)
+		if len(parts) != 2 { // most commonly due to kv's with duplicate value fields
+			ut.Unparsed = append(ut.Unparsed, field)
+			continue
 		}
 		switch parts[0] {
 		case "request_id":
@@ -94,11 +80,11 @@ func ParseUserTrafficRecord(raw string, useRegexExtractor bool) (*UserTraffic, e
 		case "result":
 			ut.Result = parts[1]
 		case "csid":
-			ut.CSID = parts[1]
+			ut.CSID = strings.TrimSuffix(parts[1], ",")
 		case "cid":
-			ut.CID = parts[1]
+			ut.CID = strings.TrimSuffix(parts[1], ",")
 		case "ccid":
-			ut.CCID = parts[1]
+			ut.CCID = strings.TrimSuffix(parts[1], ",")
 		case "status":
 			if ut.Status, err = strconv.Atoi(parts[1]); err != nil {
 				return nil, fmt.Errorf("malformed field (%s) value: %s", parts[0], parts[1])
@@ -128,34 +114,31 @@ func ParseUserTrafficRecord(raw string, useRegexExtractor bool) (*UserTraffic, e
 			//proactively handle
 			ut.AID = strings.TrimSuffix(parts[1], ",")
 		case "did":
-			ut.DID = parts[1]
+			ut.DID = strings.TrimSuffix(parts[1], ",")
 		case "cancel":
-			ut.Cancel = parts[1]
+			ut.Cancel = strings.TrimSuffix(parts[1], ",")
 		case "proxy_type":
-			ut.ProxyType = parts[1]
+			ut.ProxyType = strings.TrimSuffix(parts[1], ",")
 		case "fid":
-			ut.FID = parts[1]
+			ut.FID = strings.TrimSuffix(parts[1], ",")
 		case "content_type":
-			ut.ContentType = parts[1]
+			ut.ContentType = strings.TrimSuffix(parts[1], ",")
 		case "address":
-			ut.Address = parts[1]
+			ut.Address = strings.TrimSuffix(parts[1], ",")
 		case "country":
-			ut.Country = parts[1]
+			ut.Country = strings.TrimSuffix(parts[1], ",")
 		case "referrer":
-			ut.Referrer = parts[1]
+			ut.Referrer = strings.TrimSuffix(parts[1], ",")
 		case "cw":
-			ut.CW = parts[1]
+			ut.CW = strings.TrimSuffix(parts[1], ",")
 		case "ssl_version":
-			ut.SSLVersion = parts[1]
+			ut.SSLVersion = strings.TrimSuffix(parts[1], ",")
 		case "ssl_cipher":
-			ut.SSLCipher = parts[1]
+			ut.SSLCipher = strings.TrimSuffix(parts[1], ",")
 		case "enc":
-			ut.ENC = parts[1]
+			ut.ENC = strings.TrimSuffix(parts[1], ",")
 		default:
-			if ut.Other == nil {
-				ut.Other = make(map[string]string)
-			}
-			ut.Other[parts[0]] = parts[1]
+			ut.Unparsed = append(ut.Unparsed, field)
 		}
 	}
 	return &ut, nil

--- a/parser/user_traffic.go
+++ b/parser/user_traffic.go
@@ -55,7 +55,10 @@ func extractPair(s string, useRegex bool) []string {
 }
 
 //ParseUserTrafficRecord parses a raw user traffic log line into a UserTraffic struct
-//opting to use the regex extractor will result
+//opting to use the regex extractor will cause the parser to use a regex expression to
+//select underlying k=v value fields rather than using string splitting. The regex based
+//parser is a bit more forgiving in that it's less likely to select dangling value field
+//entries as key's.
 func ParseUserTrafficRecord(raw string, useRegexExtractor bool) (*UserTraffic, error) {
 	var ut UserTraffic
 	var err error


### PR DESCRIPTION
Changes the behaviour of the UT parser to collect any unknown kv pairs or unbalanced fields as a slice of unparsed entries (returned in the UserTraffic struct) rather than throwing an error. This is especially helpful since we somewhat frequently have duplicate value fields for keys.

For example - while auditing a sample of log lines for a Peloton site nearly 100% of the "key with no value" errors where from a country code field where the value was a duplicate like `US, US`. 

```
2020/12/04 08:29:30 ==== Errors Seen ====
2020/12/04 08:29:30 key with no value: 6341 
2020/12/04 08:29:30 missing_sid_and_csid: 1926
2020/12/04 08:29:30 lines seen: 19058
2020/12/04 08:29:30 bytes potentially billed: 611126576
2020/12/04 08:29:30 bytes potentially missed: 45379903
```

