### PR TITLE
Set status code as string on spans

### DIFF
--- a/tracing/req_tracer.go
+++ b/tracing/req_tracer.go
@@ -2,6 +2,7 @@ package tracing
 
 import (
 	"net/http"
+	"strconv"
 	"time"
 
 	opentracing "github.com/opentracing/opentracing-go"
@@ -76,7 +77,9 @@ func (rt *RequestTracer) Finish() {
 	fields["dur"] = dur.String()
 	fields["dur_ns"] = dur.Nanoseconds()
 
-	rt.span.SetTag(ext.HTTPCode, rt.trackingWriter.status)
+	// Setting the status as an int doesn't propogate for use in datadog dashboards,
+	// so we convert to a string.
+	rt.span.SetTag(ext.HTTPCode, strconv.Itoa(rt.trackingWriter.status))
 	rt.span.Finish()
 	rt.WithFields(fields).Info("Completed Request")
 }


### PR DESCRIPTION
For whatever reason, in order to use the `http.status` tag of a trace span from a datadog dashboard, the status must be written as a string,  not an integer.

See [slack conversation](https://netlify.slack.com/archives/C9D3B8RGF/p1607535957411300).
See https://github.com/netlify/gotrue/pull/272 for equivalent working change in gotrue.