### PR TITLE
make the config direct from yaml and json

### DIFF
--- a/featureflag/config.go
+++ b/featureflag/config.go
@@ -1,14 +1,13 @@
 package featureflag
 
 import (
-	"time"
-
+	"github.com/netlify/netlify-commons/util"
 	ld "gopkg.in/launchdarkly/go-server-sdk.v4"
 )
 
 type Config struct {
 	Key            string        `json:"key" yaml:"key"`
-	RequestTimeout time.Duration `json:"request_timeout" yaml:"request_timeout" mapstructure:"request_timeout" split_words:"true" default:"5s"`
+	RequestTimeout util.Duration `json:"request_timeout" yaml:"request_timeout" mapstructure:"request_timeout" split_words:"true" default:"5s"`
 	Enabled        bool          `json:"enabled" yaml:"enabled" default:"false"`
 
 	updateProcessorFactory ld.UpdateProcessorFactory

--- a/featureflag/config.go
+++ b/featureflag/config.go
@@ -11,7 +11,7 @@ type Config struct {
 	RequestTimeout time.Duration `json:"request_timeout" yaml:"request_timeout" mapstructure:"request_timeout" split_words:"true" default:"5s"`
 	Enabled        bool          `json:"enabled" yaml:"enabled" default:"false"`
 
-	updateProcessorFactory ld.UpdateProcessorFactory `json:"-"`
+	updateProcessorFactory ld.UpdateProcessorFactory
 
 	// Drop telemetry events (not needed in local-dev/CI environments)
 	DisableEvents bool `json:"disable_events" yaml:"disable_events" mapstructure:"disable_events" split_words:"true"`

--- a/featureflag/featureflag.go
+++ b/featureflag/featureflag.go
@@ -50,7 +50,7 @@ func NewClient(cfg *Config, logger logrus.FieldLogger) (Client, error) {
 		config.SendEvents = false
 	}
 
-	inner, err := ld.MakeCustomClient(cfg.Key, config, cfg.RequestTimeout)
+	inner, err := ld.MakeCustomClient(cfg.Key, config, cfg.RequestTimeout.Duration)
 	if err != nil {
 		logger.WithError(err).Error("Unable to construct LD client")
 	}

--- a/featureflag/featureflag_test.go
+++ b/featureflag/featureflag_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/netlify/netlify-commons/util"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -14,7 +15,7 @@ import (
 func TestOfflineClient(t *testing.T) {
 	cfg := Config{
 		Key:            "ABCD",
-		RequestTimeout: time.Second,
+		RequestTimeout: util.Duration{time.Second},
 		Enabled:        false,
 	}
 	client, err := NewClient(&cfg, nil)
@@ -48,7 +49,7 @@ func TestAllEnabledFlags(t *testing.T) {
 	fileSource := ldfiledata.NewFileDataSourceFactory(ldfiledata.FilePaths("./fixtures/flags.yml"))
 	cfg := Config{
 		Key:                    "ABCD",
-		RequestTimeout:         time.Second,
+		RequestTimeout:         util.Duration{time.Second},
 		Enabled:                true,
 		updateProcessorFactory: fileSource,
 	}
@@ -63,7 +64,7 @@ func TestAllEnabledFlags(t *testing.T) {
 func TestLogging(t *testing.T) {
 	cfg := Config{
 		Key:            "ABCD",
-		RequestTimeout: time.Second,
+		RequestTimeout: util.Duration{time.Second},
 		Enabled:        false,
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,6 @@ require (
 	gopkg.in/ghodss/yaml.v1 v1.0.0 // indirect
 	gopkg.in/launchdarkly/go-sdk-common.v1 v1.0.0-20200401173443-991b2f427a01 // indirect
 	gopkg.in/launchdarkly/go-server-sdk.v4 v4.0.0-20200729232655-2a44fb361895
-	gopkg.in/yaml.v2 v2.2.8
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
 )
 

--- a/go.mod
+++ b/go.mod
@@ -52,6 +52,7 @@ require (
 	gopkg.in/ghodss/yaml.v1 v1.0.0 // indirect
 	gopkg.in/launchdarkly/go-sdk-common.v1 v1.0.0-20200401173443-991b2f427a01 // indirect
 	gopkg.in/launchdarkly/go-server-sdk.v4 v4.0.0-20200729232655-2a44fb361895
+	gopkg.in/yaml.v2 v2.2.8
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
 )
 

--- a/nconf/args.go
+++ b/nconf/args.go
@@ -18,15 +18,17 @@ type RootArgs struct {
 	ConfigFile string
 }
 
+type RootConfig struct {
+	Log         LoggingConfig
+	BugSnag     *BugSnagConfig
+	Metrics     metriks.Config
+	Tracing     tracing.Config
+	FeatureFlag featureflag.Config
+}
+
 func (args *RootArgs) Setup(config interface{}, serviceName, version string) (logrus.FieldLogger, error) {
 	// first load the logger and BugSnag config
-	rootConfig := &struct {
-		Log         *LoggingConfig
-		BugSnag     *BugSnagConfig
-		Metrics     metriks.Config
-		Tracing     tracing.Config
-		FeatureFlag featureflag.Config
-	}{}
+	rootConfig := &RootConfig{}
 
 	loader := func(cfg interface{}) error {
 		return LoadFromEnv(args.Prefix, args.ConfigFile, cfg)

--- a/nconf/args.go
+++ b/nconf/args.go
@@ -30,16 +30,7 @@ func (args *RootArgs) Setup(config interface{}, serviceName, version string) (lo
 	// first load the logger and BugSnag config
 	rootConfig := &RootConfig{}
 
-	loader := func(cfg interface{}) error {
-		return LoadFromEnv(args.Prefix, args.ConfigFile, cfg)
-	}
-	if !strings.HasSuffix(args.ConfigFile, ".env") {
-		loader = func(cfg interface{}) error {
-			return LoadFromFile(args.ConfigFile, cfg)
-		}
-	}
-
-	if err := loader(rootConfig); err != nil {
+	if err := args.load(rootConfig); err != nil {
 		return nil, errors.Wrap(err, "Failed to load the logging configuration")
 	}
 
@@ -73,7 +64,7 @@ func (args *RootArgs) Setup(config interface{}, serviceName, version string) (lo
 
 	if config != nil {
 		// second load the config for this project
-		if err := loader(config); err != nil {
+		if err := args.load(config); err != nil {
 			return log, errors.Wrap(err, "Failed to load the config object")
 		}
 		log.Debug("Loaded configuration")

--- a/nconf/args.go
+++ b/nconf/args.go
@@ -79,6 +79,18 @@ func (args *RootArgs) Setup(config interface{}, serviceName, version string) (lo
 	return log, nil
 }
 
+func (args *RootArgs) load(cfg interface{}) error {
+	loader := func(cfg interface{}) error {
+		return LoadFromEnv(args.Prefix, args.ConfigFile, cfg)
+	}
+	if !strings.HasSuffix(args.ConfigFile, ".env") {
+		loader = func(cfg interface{}) error {
+			return LoadConfigFromFile(args.ConfigFile, cfg)
+		}
+	}
+	return loader(cfg)
+}
+
 func (args *RootArgs) MustSetup(config interface{}, serviceName, version string) logrus.FieldLogger {
 	logger, err := args.Setup(config, serviceName, version)
 	if err != nil {

--- a/nconf/args.go
+++ b/nconf/args.go
@@ -27,11 +27,9 @@ type RootConfig struct {
 }
 
 func (args *RootArgs) Setup(config interface{}, serviceName, version string) (logrus.FieldLogger, error) {
-	// first load the logger and BugSnag config
-	rootConfig := &RootConfig{}
-
-	if err := args.load(rootConfig); err != nil {
-		return nil, errors.Wrap(err, "Failed to load the logging configuration")
+	rootConfig, err := args.loadDefaultConfig()
+	if err != nil {
+		return nil, err
 	}
 
 	log, err := ConfigureLogging(rootConfig.Log)
@@ -95,6 +93,17 @@ func (args *RootArgs) MustSetup(config interface{}, serviceName, version string)
 	}
 
 	return logger
+}
+
+func (args *RootArgs) loadDefaultConfig() (*RootConfig, error) {
+	c := &RootConfig{
+		Log: DefaultLoggingConfig(),
+	}
+
+	if err := args.load(c); err != nil {
+		return nil, errors.Wrap(err, "Failed to load the logging configuration")
+	}
+	return c, nil
 }
 
 func (args *RootArgs) AddFlags(cmd *cobra.Command) *cobra.Command {

--- a/nconf/args.go
+++ b/nconf/args.go
@@ -18,14 +18,6 @@ type RootArgs struct {
 	ConfigFile string
 }
 
-type RootConfig struct {
-	Log         LoggingConfig
-	BugSnag     *BugSnagConfig
-	Metrics     metriks.Config
-	Tracing     tracing.Config
-	FeatureFlag featureflag.Config
-}
-
 func (args *RootArgs) Setup(config interface{}, serviceName, version string) (logrus.FieldLogger, error) {
 	rootConfig, err := args.loadDefaultConfig()
 	if err != nil {
@@ -96,14 +88,13 @@ func (args *RootArgs) MustSetup(config interface{}, serviceName, version string)
 }
 
 func (args *RootArgs) loadDefaultConfig() (*RootConfig, error) {
-	c := &RootConfig{
-		Log: DefaultLoggingConfig(),
-	}
+	c := DefaultConfig()
 
-	if err := args.load(c); err != nil {
+	if err := args.load(&c); err != nil {
 		return nil, errors.Wrap(err, "Failed to load the default configuration")
 	}
-	return c, nil
+
+	return &c, nil
 }
 
 func (args *RootArgs) AddFlags(cmd *cobra.Command) *cobra.Command {

--- a/nconf/args.go
+++ b/nconf/args.go
@@ -101,7 +101,7 @@ func (args *RootArgs) loadDefaultConfig() (*RootConfig, error) {
 	}
 
 	if err := args.load(c); err != nil {
-		return nil, errors.Wrap(err, "Failed to load the logging configuration")
+		return nil, errors.Wrap(err, "Failed to load the default configuration")
 	}
 	return c, nil
 }

--- a/nconf/args_test.go
+++ b/nconf/args_test.go
@@ -93,7 +93,7 @@ func TestArgsLoadDefault(t *testing.T) {
 		},
 		"tracing": map[string]interface{}{
 			"enabled":      true,
-			"port":         "8125",
+			"port":         "9125",
 			"enable_debug": true,
 		},
 		"featureflag": map[string]interface{}{
@@ -146,14 +146,14 @@ func TestArgsLoadDefault(t *testing.T) {
 
 			// metrics
 			assert.Equal(t, true, cfg.Metrics.Enabled)
-			assert.Equal(t, "", cfg.Metrics.Host)
+			assert.Equal(t, "localhost", cfg.Metrics.Host)
 			assert.Equal(t, 8125, cfg.Metrics.Port)
 			assert.Equal(t, map[string]string{"env": "prod"}, cfg.Metrics.Tags)
 
 			// tracing
 			assert.Equal(t, true, cfg.Tracing.Enabled)
-			assert.Equal(t, "", cfg.Tracing.Host)
-			assert.Equal(t, "8125", cfg.Tracing.Port)
+			assert.Equal(t, "localhost", cfg.Tracing.Host)
+			assert.Equal(t, "9125", cfg.Tracing.Port)
 			assert.Empty(t, cfg.Tracing.Tags)
 			assert.Equal(t, true, cfg.Tracing.EnableDebug)
 
@@ -165,46 +165,4 @@ func TestArgsLoadDefault(t *testing.T) {
 			assert.Equal(t, "", cfg.FeatureFlag.RelayHost)
 		})
 	}
-}
-
-func TestArgsLoadFromYAML(t *testing.T) {
-	f, err := ioutil.TempFile("", "test-config-*.yaml")
-	require.NoError(t, err)
-	defer os.Remove(f.Name())
-
-	args := RootArgs{
-		ConfigFile: f.Name(),
-	}
-
-	t.Run("empty-file", func(t *testing.T) {
-		cfg := RootConfig{
-			Log: DefaultLoggingConfig(),
-		}
-		require.NoError(t, args.load(&cfg))
-
-		assert.True(t, cfg.Log.QuoteEmptyFields)
-		assert.Equal(t, DefaultLoggingConfig(), cfg.Log)
-		assert.Nil(t, cfg.BugSnag)
-	})
-
-	_, err = f.WriteString(`
-log:
-  level: debug
-  fields:
-    string: value
-    int: 4
-`)
-	require.NoError(t, err)
-
-	t.Run("set log field", func(t *testing.T) {
-		cfg := RootConfig{Log: DefaultLoggingConfig()}
-		require.NoError(t, args.load(&cfg))
-
-		// retains original value
-		assert.True(t, cfg.Log.QuoteEmptyFields)
-		assert.Equal(t, "debug", cfg.Log.Level)
-		require.Len(t, cfg.Log.Fields, 2)
-		assert.Equal(t, "value", cfg.Log.Fields["string"])
-		assert.Equal(t, 4, cfg.Log.Fields["int"])
-	})
 }

--- a/nconf/args_test.go
+++ b/nconf/args_test.go
@@ -2,6 +2,7 @@ package nconf
 
 import (
 	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -66,4 +67,46 @@ func TestArgsAddToCmd(t *testing.T) {
 	cmd.SetArgs([]string{"--config", "file.env", "--prefix", "PF"})
 	require.NoError(t, cmd.Execute())
 	assert.Equal(t, 1, called)
+}
+
+func TestArgsLoadFromYAML(t *testing.T) {
+	f, err := ioutil.TempFile("", "test-config-*.yaml")
+	require.NoError(t, err)
+	defer os.Remove(f.Name())
+
+	args := RootArgs{
+		ConfigFile: f.Name(),
+	}
+
+	t.Run("empty-file", func(t *testing.T) {
+		cfg := RootConfig{
+			Log: DefaultLoggingConfig,
+		}
+		require.NoError(t, args.load(&cfg))
+
+		assert.True(t, cfg.Log.QuoteEmptyFields)
+		assert.Equal(t, DefaultLoggingConfig, cfg.Log)
+		assert.Empty(t, cfg.BugSnag.APIKey)
+	})
+
+	_, err = f.WriteString(`
+log:
+  level: debug
+  fields:
+    string: value
+    int: 4
+`)
+	require.NoError(t, err)
+
+	t.Run("set log field", func(t *testing.T) {
+		cfg := RootConfig{Log: DefaultLoggingConfig}
+		require.NoError(t, args.load(&cfg))
+
+		// retains original value
+		assert.True(t, cfg.Log.QuoteEmptyFields)
+		assert.Equal(t, "debug", cfg.Log.Level)
+		require.Len(t, cfg.Log.Fields, 2)
+		assert.Equal(t, "value", cfg.Log.Fields["string"])
+		assert.Equal(t, 4, cfg.Log.Fields["int"])
+	})
 }

--- a/nconf/args_test.go
+++ b/nconf/args_test.go
@@ -1,11 +1,14 @@
 package nconf
 
 import (
+	"encoding/json"
 	"io/ioutil"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -67,6 +70,101 @@ func TestArgsAddToCmd(t *testing.T) {
 	cmd.SetArgs([]string{"--config", "file.env", "--prefix", "PF"})
 	require.NoError(t, cmd.Execute())
 	assert.Equal(t, 1, called)
+}
+
+func TestArgsLoadDefault(t *testing.T) {
+	configVals := map[string]interface{}{
+		"log": map[string]interface{}{
+			"level": "debug",
+			"fields": map[string]interface{}{
+				"something": 1,
+			},
+		},
+		"bugsnag": map[string]interface{}{
+			"api_key":         "secrets",
+			"project_package": "package",
+		},
+		"metrics": map[string]interface{}{
+			"enabled": true,
+			"port":    8125,
+			"tags": map[string]string{
+				"env": "prod",
+			},
+		},
+		"tracing": map[string]interface{}{
+			"enabled":      true,
+			"port":         "8125",
+			"enable_debug": true,
+		},
+		"featureflag": map[string]interface{}{
+			"key":             "magicalkey",
+			"request_timeout": "10s",
+			"enabled":         true,
+		},
+	}
+
+	scenes := []struct {
+		ext string
+		enc func(v interface{}) ([]byte, error)
+	}{
+		{"json", json.Marshal},
+		{"yaml", yaml.Marshal},
+	}
+	for _, s := range scenes {
+		t.Run(s.ext, func(t *testing.T) {
+			f, err := ioutil.TempFile("", "test-config-*."+s.ext)
+			require.NoError(t, err)
+			defer os.Remove(f.Name())
+
+			b, err := s.enc(&configVals)
+			require.NoError(t, err)
+			_, err = f.Write(b)
+			require.NoError(t, err)
+
+			args := RootArgs{
+				ConfigFile: f.Name(),
+			}
+			cfg, err := args.loadDefaultConfig()
+			require.NoError(t, err)
+
+			// logging
+			assert.Equal(t, "debug", cfg.Log.Level)
+			assert.Equal(t, true, cfg.Log.QuoteEmptyFields)
+			assert.Equal(t, "", cfg.Log.File)
+			assert.Equal(t, false, cfg.Log.DisableColors)
+			assert.Equal(t, "", cfg.Log.TSFormat)
+
+			assert.Len(t, cfg.Log.Fields, 1)
+			assert.EqualValues(t, 1, cfg.Log.Fields["something"])
+			assert.Equal(t, false, cfg.Log.UseNewLogger)
+
+			// bugsnag
+			assert.Equal(t, "", cfg.BugSnag.Environment)
+			assert.Equal(t, "secrets", cfg.BugSnag.APIKey)
+			assert.Equal(t, false, cfg.BugSnag.LogHook)
+			assert.Equal(t, "package", cfg.BugSnag.ProjectPackage)
+
+			// metrics
+			assert.Equal(t, true, cfg.Metrics.Enabled)
+			assert.Equal(t, "", cfg.Metrics.Host)
+			assert.Equal(t, 8125, cfg.Metrics.Port)
+			assert.Equal(t, map[string]string{"env": "prod"}, cfg.Metrics.Tags)
+
+			// tracing
+			assert.Equal(t, true, cfg.Tracing.Enabled)
+			assert.Equal(t, "", cfg.Tracing.Host)
+			assert.Equal(t, "8125", cfg.Tracing.Port)
+			assert.Empty(t, cfg.Tracing.Tags)
+			assert.Equal(t, true, cfg.Tracing.EnableDebug)
+
+			// featureflag
+			assert.Equal(t, "magicalkey", cfg.FeatureFlag.Key)
+			assert.Equal(t, 10*time.Second, cfg.FeatureFlag.RequestTimeout.Duration)
+			assert.Equal(t, true, cfg.FeatureFlag.Enabled)
+			assert.Equal(t, false, cfg.FeatureFlag.DisableEvents)
+			assert.Equal(t, "", cfg.FeatureFlag.RelayHost)
+		})
+	}
 }
 
 func TestArgsLoadFromYAML(t *testing.T) {

--- a/nconf/args_test.go
+++ b/nconf/args_test.go
@@ -7,13 +7,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
-
 	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
-
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 func TestArgsLoad(t *testing.T) {

--- a/nconf/args_test.go
+++ b/nconf/args_test.go
@@ -80,13 +80,13 @@ func TestArgsLoadFromYAML(t *testing.T) {
 
 	t.Run("empty-file", func(t *testing.T) {
 		cfg := RootConfig{
-			Log: DefaultLoggingConfig,
+			Log: DefaultLoggingConfig(),
 		}
 		require.NoError(t, args.load(&cfg))
 
 		assert.True(t, cfg.Log.QuoteEmptyFields)
-		assert.Equal(t, DefaultLoggingConfig, cfg.Log)
-		assert.Empty(t, cfg.BugSnag.APIKey)
+		assert.Equal(t, DefaultLoggingConfig(), cfg.Log)
+		assert.Nil(t, cfg.BugSnag)
 	})
 
 	_, err = f.WriteString(`
@@ -99,7 +99,7 @@ log:
 	require.NoError(t, err)
 
 	t.Run("set log field", func(t *testing.T) {
-		cfg := RootConfig{Log: DefaultLoggingConfig}
+		cfg := RootConfig{Log: DefaultLoggingConfig()}
 		require.NoError(t, args.load(&cfg))
 
 		// retains original value

--- a/nconf/bugsnag.go
+++ b/nconf/bugsnag.go
@@ -8,16 +8,16 @@ import (
 
 type BugSnagConfig struct {
 	Environment    string
-	APIKey         string `envconfig:"api_key"`
-	LogHook        bool   `envconfig:"log_hook"`
-	ProjectPackage string `envconfig:"project_package"`
+	APIKey         string `envconfig:"api_key" json:"api_key" yaml:"api_key"`
+	LogHook        bool   `envconfig:"log_hook" json:"log_hook" yaml:"log_hook"`
+	ProjectPackage string `envconfig:"project_package" json:"project_package" yaml:"project_package"`
 }
 
 func SetupBugSnag(config *BugSnagConfig, version string) error {
 	if config == nil || config.APIKey == "" {
 		return nil
 	}
-	
+
 	projectPackages := make([]string, 0, 2)
 	projectPackages = append(projectPackages, "main")
 	if config.ProjectPackage != "" {
@@ -25,11 +25,11 @@ func SetupBugSnag(config *BugSnagConfig, version string) error {
 	}
 
 	bugsnag.Configure(bugsnag.Configuration{
-		APIKey:       config.APIKey,
-		ReleaseStage: config.Environment,
-		AppVersion:   version,
-		ProjectPackages: projectPackages, 
-		PanicHandler: func() {}, // this is to disable panic handling. The lib was forking and restarting the process (causing races)
+		APIKey:          config.APIKey,
+		ReleaseStage:    config.Environment,
+		AppVersion:      version,
+		ProjectPackages: projectPackages,
+		PanicHandler:    func() {}, // this is to disable panic handling. The lib was forking and restarting the process (causing races)
 	})
 
 	if config.LogHook {

--- a/nconf/configuration.go
+++ b/nconf/configuration.go
@@ -8,15 +8,14 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/joho/godotenv"
+	"github.com/kelseyhightower/envconfig"
 	"github.com/netlify/netlify-commons/featureflag"
 	"github.com/netlify/netlify-commons/metriks"
 	"github.com/netlify/netlify-commons/tracing"
-
-	"github.com/joho/godotenv"
-	"github.com/kelseyhightower/envconfig"
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 // ErrUnknownConfigFormat indicates the extension of the config file is not supported as a config source

--- a/nconf/configuration.go
+++ b/nconf/configuration.go
@@ -8,6 +8,10 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/netlify/netlify-commons/featureflag"
+	"github.com/netlify/netlify-commons/metriks"
+	"github.com/netlify/netlify-commons/tracing"
+
 	"github.com/joho/godotenv"
 	"github.com/kelseyhightower/envconfig"
 	"github.com/pkg/errors"
@@ -22,6 +26,30 @@ type ErrUnknownConfigFormat struct {
 
 func (e *ErrUnknownConfigFormat) Error() string {
 	return fmt.Sprintf("Unknown config format: %s", e.ext)
+}
+
+type RootConfig struct {
+	Log         LoggingConfig
+	BugSnag     *BugSnagConfig
+	Metrics     metriks.Config
+	Tracing     tracing.Config
+	FeatureFlag featureflag.Config
+}
+
+func DefaultConfig() RootConfig {
+	return RootConfig{
+		Log: LoggingConfig{
+			QuoteEmptyFields: true,
+		},
+		Tracing: tracing.Config{
+			Host: "localhost",
+			Port: "8126",
+		},
+		Metrics: metriks.Config{
+			Host: "localhost",
+			Port: 8125,
+		},
+	}
 }
 
 /*

--- a/nconf/configuration_test.go
+++ b/nconf/configuration_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
 )
 
 type testConfig struct {
@@ -98,7 +99,7 @@ func TestFileLoadJSON(t *testing.T) {
 
 func TestFileLoadYAML(t *testing.T) {
 	expected := exampleConfig()
-	bytes, err := json.Marshal(&expected)
+	bytes, err := yaml.Marshal(&expected)
 	require.NoError(t, err)
 	filename := writeTestFile(t, "yaml", bytes)
 	defer os.Remove(filename)

--- a/nconf/configuration_test.go
+++ b/nconf/configuration_test.go
@@ -12,10 +12,12 @@ import (
 )
 
 type testConfig struct {
-	Hero     string            `json:",omitempty"`
-	Villian  string            `json:",omitempty"`
-	Matchups map[string]string `json:",omitempty"`
-	Cities   []string          `json:",omitempty"`
+	Hero     string
+	Villian  string
+	Matchups map[string]string
+	Cities   []string
+
+	ShootingLocation string `json:"shooting_location" yaml:"shooting_location" split_words:"true"`
 }
 
 func exampleConfig() testConfig {
@@ -90,7 +92,7 @@ func TestFileLoadJSON(t *testing.T) {
 	defer os.Remove(filename)
 
 	var results testConfig
-	require.NoError(t, LoadFromFile(filename, &results))
+	require.NoError(t, LoadConfigFromFile(filename, &results))
 	validateConfig(t, expected, results)
 }
 
@@ -102,7 +104,7 @@ func TestFileLoadYAML(t *testing.T) {
 	defer os.Remove(filename)
 
 	var results testConfig
-	require.NoError(t, LoadFromFile(filename, &results))
+	require.NoError(t, LoadConfigFromFile(filename, &results))
 	validateConfig(t, expected, results)
 }
 

--- a/nconf/configuration_test.go
+++ b/nconf/configuration_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 type testConfig struct {

--- a/nconf/logging.go
+++ b/nconf/logging.go
@@ -17,12 +17,6 @@ type LoggingConfig struct {
 	UseNewLogger     bool                   `mapstructure:"use_new_logger" split_words:"true" json:"use_new_logger" yaml:"use_new_logger"`
 }
 
-func DefaultLoggingConfig() LoggingConfig {
-	return LoggingConfig{
-		QuoteEmptyFields: true,
-	}
-}
-
 func ConfigureLogging(config LoggingConfig) (*logrus.Entry, error) {
 	logger := logrus.New()
 

--- a/nconf/logging.go
+++ b/nconf/logging.go
@@ -17,7 +17,13 @@ type LoggingConfig struct {
 	UseNewLogger     bool                   `mapstructure:"use_new_logger" split_words:"true" json:"use_new_logger" yaml:"use_new_logger"`
 }
 
-func ConfigureLogging(config *LoggingConfig) (*logrus.Entry, error) {
+func DefaultLoggingConfig() LoggingConfig {
+	return LoggingConfig{
+		QuoteEmptyFields: true,
+	}
+}
+
+func ConfigureLogging(config LoggingConfig) (*logrus.Entry, error) {
 	logger := logrus.New()
 
 	tsFormat := time.RFC3339Nano

--- a/nconf/logging.go
+++ b/nconf/logging.go
@@ -8,13 +8,13 @@ import (
 )
 
 type LoggingConfig struct {
-	Level            string                 `mapstructure:"log_level" json:"log_level"`
-	File             string                 `mapstructure:"log_file" json:"log_file"`
-	DisableColors    bool                   `mapstructure:"disable_colors" split_words:"true" json:"disable_colors"`
-	QuoteEmptyFields bool                   `mapstructure:"quote_empty_fields" split_words:"true" json:"quote_empty_fields"`
-	TSFormat         string                 `mapstructure:"ts_format" json:"ts_format"`
-	Fields           map[string]interface{} `mapstructure:"fields" json:"fields"`
-	UseNewLogger     bool                   `mapstructure:"use_new_logger",split_words:"true"`
+	Level            string                 `mapstructure:"log_level"`
+	File             string                 `mapstructure:"log_file"`
+	DisableColors    bool                   `mapstructure:"disable_colors" split_words:"true" json:"disable_colors" yaml:"disable_colors"`
+	QuoteEmptyFields bool                   `mapstructure:"quote_empty_fields" split_words:"true" json:"quote_empty_fields" yaml:"quote_empty_fields"`
+	TSFormat         string                 `mapstructure:"ts_format" json:"ts_format" yaml:"ts_format"`
+	Fields           map[string]interface{} `mapstructure:"fields"`
+	UseNewLogger     bool                   `mapstructure:"use_new_logger" split_words:"true" json:"use_new_logger" yaml:"use_new_logger"`
 }
 
 func ConfigureLogging(config *LoggingConfig) (*logrus.Entry, error) {

--- a/nconf/timeout.go
+++ b/nconf/timeout.go
@@ -18,12 +18,12 @@ type HTTPClientTimeoutConfig struct {
 	// Dial = net.Dialer.Timeout
 	Dial time.Duration `mapstructure:"dial"`
 	// KeepAlive = net.Dialer.KeepAlive
-	KeepAlive time.Duration `mapstructure:"keep_alive" split_words:"true"`
+	KeepAlive time.Duration `mapstructure:"keep_alive" split_words:"true" json:"keep_alive" yaml:"keep_alive"`
 
 	// TLSHandshake = http.Transport.TLSHandshakeTimeout
-	TLSHandshake time.Duration `mapstructure:"tls_handshake" split_words:"true"`
+	TLSHandshake time.Duration `mapstructure:"tls_handshake" split_words:"true" json:"tls_handshake" yaml:"tls_handshake"`
 	// ResponseHeader = http.Transport.ResponseHeaderTimeout
-	ResponseHeader time.Duration `mapstructure:"response_header" split_words:"true"`
+	ResponseHeader time.Duration `mapstructure:"response_header" split_words:"true" json:"response_header" yaml:"response_header"`
 	// Total = http.Client.Timeout or equivalent
 	// The maximum amount of time a client request can take.
 	Total time.Duration `mapstructure:"total"`

--- a/nconf/timeout.go
+++ b/nconf/timeout.go
@@ -1,30 +1,32 @@
 package nconf
 
-import "time"
+import (
+	"github.com/netlify/netlify-commons/util"
+)
 
 // HTTPServerTimeoutConfig represents common HTTP server timeout values
 type HTTPServerTimeoutConfig struct {
 	// Read = http.Server.ReadTimeout
-	Read time.Duration `mapstructure:"read"`
+	Read util.Duration `mapstructure:"read"`
 	// Write = http.Server.WriteTimeout
-	Write time.Duration `mapstructure:"write"`
+	Write util.Duration `mapstructure:"write"`
 	// Handler = http.TimeoutHandler (or equivalent).
 	// The maximum amount of time a server handler can take.
-	Handler time.Duration `mapstructure:"handler"`
+	Handler util.Duration `mapstructure:"handler"`
 }
 
 // HTTPClientTimeoutConfig represents common HTTP client timeout values
 type HTTPClientTimeoutConfig struct {
 	// Dial = net.Dialer.Timeout
-	Dial time.Duration `mapstructure:"dial"`
+	Dial util.Duration `mapstructure:"dial"`
 	// KeepAlive = net.Dialer.KeepAlive
-	KeepAlive time.Duration `mapstructure:"keep_alive" split_words:"true" json:"keep_alive" yaml:"keep_alive"`
+	KeepAlive util.Duration `mapstructure:"keep_alive" split_words:"true" json:"keep_alive" yaml:"keep_alive"`
 
 	// TLSHandshake = http.Transport.TLSHandshakeTimeout
-	TLSHandshake time.Duration `mapstructure:"tls_handshake" split_words:"true" json:"tls_handshake" yaml:"tls_handshake"`
+	TLSHandshake util.Duration `mapstructure:"tls_handshake" split_words:"true" json:"tls_handshake" yaml:"tls_handshake"`
 	// ResponseHeader = http.Transport.ResponseHeaderTimeout
-	ResponseHeader time.Duration `mapstructure:"response_header" split_words:"true" json:"response_header" yaml:"response_header"`
+	ResponseHeader util.Duration `mapstructure:"response_header" split_words:"true" json:"response_header" yaml:"response_header"`
 	// Total = http.Client.Timeout or equivalent
 	// The maximum amount of time a client request can take.
-	Total time.Duration `mapstructure:"total"`
+	Total util.Duration `mapstructure:"total"`
 }

--- a/nconf/timeout_test.go
+++ b/nconf/timeout_test.go
@@ -1,0 +1,53 @@
+package nconf
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+)
+
+func TestParseTimeoutValues(t *testing.T) {
+	raw := map[string]string{
+		"dial":            "10s",
+		"keep_alive":      "11s",
+		"tls_handshake":   "12s",
+		"response_header": "13s",
+		"total":           "14s",
+	}
+
+	// write it to json & yaml
+	// then load it through the RootArgs.load
+	scenes := []struct {
+		name string
+		enc  func(interface{}) ([]byte, error)
+		dec  func([]byte, interface{}) error
+	}{
+		{"json", json.Marshal, json.Unmarshal},
+		{"yaml", yaml.Marshal, yaml.Unmarshal},
+	}
+	for _, s := range scenes {
+		t.Run(s.name, func(t *testing.T) {
+			bs, err := s.enc(&raw)
+			require.NoError(t, err)
+
+			var cfg HTTPClientTimeoutConfig
+
+			require.NoError(t, s.dec(bs, &cfg))
+
+			assert.Equal(t, "10s", cfg.Dial.String())
+			assert.Equal(t, "11s", cfg.KeepAlive.String())
+			assert.Equal(t, "12s", cfg.TLSHandshake.String())
+			assert.Equal(t, "13s", cfg.ResponseHeader.String())
+			assert.Equal(t, "14s", cfg.Total.String())
+			assert.Equal(t, 10*time.Second, cfg.Dial.Duration)
+			assert.Equal(t, 11*time.Second, cfg.KeepAlive.Duration)
+			assert.Equal(t, 12*time.Second, cfg.TLSHandshake.Duration)
+			assert.Equal(t, 13*time.Second, cfg.ResponseHeader.Duration)
+			assert.Equal(t, 14*time.Second, cfg.Total.Duration)
+		})
+	}
+}

--- a/nconf/timeout_test.go
+++ b/nconf/timeout_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 func TestParseTimeoutValues(t *testing.T) {

--- a/nconf/tls.go
+++ b/nconf/tls.go
@@ -10,9 +10,9 @@ import (
 )
 
 type TLSConfig struct {
-	CAFiles  []string `mapstructure:"ca_files" envconfig:"ca_files"`
-	KeyFile  string   `mapstructure:"key_file" split_words:"true"`
-	CertFile string   `mapstructure:"cert_file" split_words:"true"`
+	CAFiles  []string `mapstructure:"ca_files" envconfig:"ca_files" json:"ca_files" yaml:"ca_files"`
+	KeyFile  string   `mapstructure:"key_file" split_words:"true" json:"key_file" yaml:"key_file"`
+	CertFile string   `mapstructure:"cert_file" split_words:"true" json:"cert_file" yaml:"cert_file"`
 
 	Cert string `mapstructure:"cert"`
 	Key  string `mapstructure:"key"`

--- a/tracing/config.go
+++ b/tracing/config.go
@@ -19,7 +19,7 @@ type Config struct {
 	Host        string `default:"localhost"`
 	Port        string `default:"8126"`
 	Tags        map[string]string
-	EnableDebug bool `default:"false" split_words:"true" mapstructure:"enable_debug"`
+	EnableDebug bool `default:"false" split_words:"true" mapstructure:"enable_debug" json:"enable_debug" yaml:"enable_debug"`
 }
 
 func Configure(tc *Config, log logrus.FieldLogger, svcName string) {

--- a/util/duration.go
+++ b/util/duration.go
@@ -1,0 +1,65 @@
+package util
+
+import (
+	"encoding/json"
+	"errors"
+	"time"
+
+	"gopkg.in/yaml.v2"
+)
+
+// Duration is a serializable version version of a time.Duration
+// it supports setting in yaml & json via:
+// - string: 10s
+// - float32/64, int/32/64: 10 (nanoseconds)
+type Duration struct {
+	time.Duration
+}
+
+func (d Duration) MarshalYAML() ([]byte, error) {
+	return yaml.Marshal(d.String())
+}
+
+func (d Duration) MarshalJSON() ([]byte, error) {
+	return json.Marshal(d.String())
+}
+
+func (d *Duration) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var v interface{}
+	if err := unmarshal(&v); err != nil {
+		return err
+	}
+	return d.setValue(v)
+}
+
+func (d *Duration) UnmarshalJSON(b []byte) error {
+	var v interface{}
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+	return d.setValue(v)
+}
+
+func (d *Duration) setValue(v interface{}) error {
+	switch value := v.(type) {
+	case float64:
+		d.Duration = time.Duration(value)
+	case float32:
+		d.Duration = time.Duration(value)
+	case int:
+		d.Duration = time.Duration(value)
+	case int32:
+		d.Duration = time.Duration(value)
+	case int64:
+		d.Duration = time.Duration(value)
+	case string:
+		var err error
+		d.Duration, err = time.ParseDuration(value)
+		if err != nil {
+			return err
+		}
+	default:
+		return errors.New("invalid duration")
+	}
+	return nil
+}

--- a/util/duration.go
+++ b/util/duration.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"time"
 
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 // Duration is a serializable version version of a time.Duration

--- a/util/duration_test.go
+++ b/util/duration_test.go
@@ -1,0 +1,53 @@
+package util
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+)
+
+func TestDurationParsing(t *testing.T) {
+	scenes := []struct {
+		name string
+		dur  interface{}
+	}{
+		{"float", 1e9},
+		{"int", int(1e9)},
+		{"str", "1s"},
+	}
+
+	for _, s := range scenes {
+		t.Run(s.name, func(t *testing.T) {
+			cfg := struct {
+				Dur interface{}
+			}{
+				Dur: s.dur,
+			}
+			t.Run("yaml", func(t *testing.T) {
+				bs, err := yaml.Marshal(&cfg)
+				require.NoError(t, err)
+
+				res := struct {
+					Dur Duration
+				}{}
+				require.NoError(t, yaml.Unmarshal(bs, &res))
+				assert.Equal(t, time.Second, res.Dur.Duration)
+			})
+
+			t.Run("json", func(t *testing.T) {
+				bs, err := json.Marshal(&cfg)
+				require.NoError(t, err)
+				res := struct {
+					Dur Duration
+				}{}
+
+				require.NoError(t, json.Unmarshal(bs, &res))
+				assert.Equal(t, time.Second, res.Dur.Duration)
+			})
+		})
+	}
+}

--- a/util/duration_test.go
+++ b/util/duration_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 func TestDurationParsing(t *testing.T) {


### PR DESCRIPTION
Ok the old code was doing a bytes -> map[string]interface{} -> mapstructure. This was very confusing (and didn't seem to be working?) so this actually just simplifies it to be json/yaml directly.

What it means is that anyone using this will need to add the json/yaml tags to their struct (and can lose the mapstructure). I think that it makes it a bit clearer