### PR TITLE
Add go version 1.16.x to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.14.x", "1.15.x"]
+        go: ["1.14.x", "1.15.x", "1.16.x"]
     steps:
       - uses: actions/checkout@master
       - uses: actions/setup-go@v1


### PR DESCRIPTION
Addressing @mheffner comment in https://github.com/netlify/go-service-boilerplate/pull/27
Let's make sure that netlify-commons works with 1.16.

We really should fix that flappy tests though, let's see how it goes.