### PR TITLE
feat: add ability to specify hostname in server

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -28,6 +28,7 @@ type Server struct {
 type Config struct {
 	HealthPath string `split_words:"true"`
 	Port       int
+	Host       string
 	TLS        nconf.TLSConfig
 }
 
@@ -72,7 +73,7 @@ func New(log logrus.FieldLogger, config Config, api APIDefinition) (*Server, err
 	s := Server{
 		log: log.WithField("component", "server"),
 		svr: &http.Server{
-			Addr:    fmt.Sprintf(":%d", config.Port),
+			Addr:    fmt.Sprintf("%s:%d", config.Host, config.Port),
 			Handler: r,
 		},
 		api:  api,

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -145,3 +145,15 @@ func testConfig() Config {
 		Port:       9090,
 	}
 }
+
+func TestServerAddr(t *testing.T) {
+	apiDef := new(testAPICustomHealth)
+	cfg := testConfig()
+	svr, err := New(tl(t), cfg, apiDef)
+	require.NoError(t, err)
+	require.Equal(t, svr.svr.Addr, ":9090")
+	cfg.Host = "127.0.0.1"
+	svrWithHost, err := New(tl(t), cfg, apiDef)
+	require.NoError(t, err)
+	require.Equal(t, svrWithHost.svr.Addr, "127.0.0.1:9090")
+}


### PR DESCRIPTION
- allows us to specify the hostname in the server config
- should not break existing config, if the host isn't set, we should still get the same results