### PR TITLE
build in distribution metrics for datadog sink

### DIFF
--- a/metriks/distribution.go
+++ b/metriks/distribution.go
@@ -13,7 +13,7 @@ var (
 	distributionErrorHandler = func(_ error) {}
 )
 
-func initDistribution(url string, name string, permTags []string) error {
+func initDistribution(url string, serviceName string, permTags []string) error {
 	statsd, err := statsd.New(url)
 	if err != nil {
 		return err
@@ -21,7 +21,7 @@ func initDistribution(url string, name string, permTags []string) error {
 
 	distributionFunc = func(name string, value float64, tags ...metrics.Label) {
 		ddtags := append(permTags, convertTags(tags)...)
-		name = fmt.Sprintf("%s.%s", name, strings.ReplaceAll(name, "-", "_"))
+		name = fmt.Sprintf("%s.%s", serviceName, strings.ReplaceAll(name, "-", "_"))
 
 		err := statsd.Distribution(name, float64(value), ddtags, 1)
 		if err != nil {

--- a/metriks/distribution.go
+++ b/metriks/distribution.go
@@ -1,0 +1,54 @@
+package metriks
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/DataDog/datadog-go/statsd"
+	"github.com/armon/go-metrics"
+)
+
+var (
+	distributionFunc         = func(name string, value float64, tags ...metrics.Label) {}
+	distributionErrorHandler = func(_ error) {}
+)
+
+func initDistribution(url string, name string, permTags []string) error {
+	statsd, err := statsd.New(url)
+	if err != nil {
+		return err
+	}
+
+	distributionFunc = func(name string, value float64, tags ...metrics.Label) {
+		ddtags := append(permTags, convertTags(tags)...)
+		name = fmt.Sprintf("%s.%s", name, strings.ReplaceAll(name, "-", "_"))
+
+		err := statsd.Distribution(name, float64(value), ddtags, 1)
+		if err != nil {
+			distributionErrorHandler(err)
+		}
+	}
+
+	return nil
+}
+
+// SetDistributionErrorHandler will set the global error handler. It will be invoked
+// anytime that the statsd call produces an error
+func SetDistributionErrorHandler(f func(error)) {
+	distributionErrorHandler = f
+}
+
+// Distribution will report the value as a distribution metric to datadog.
+// it only makes sense when you're using the datadog sink
+func Distribution(name string, value float64, tags ...metrics.Label) {
+	distributionFunc(name, value, tags...)
+}
+
+func convertTags(incoming []metrics.Label) []string {
+	tags := []string{}
+	for _, v := range incoming {
+		tags = append(tags, fmt.Sprintf("%s:%s", v.Name, v.Value))
+	}
+	return tags
+
+}

--- a/metriks/distribution_test.go
+++ b/metriks/distribution_test.go
@@ -31,5 +31,5 @@ func TestDistribution(t *testing.T) {
 	Distribution("some_metric", 12.0, L("b", "c"))
 
 	buf := <-msgs
-	assert.Equal(t, "some_metric.some_metric:12|d|#a:1,b:c", string(bytes.Trim(buf, "\x00")))
+	assert.Equal(t, "testing.some_metric:12|d|#a:1,b:c", string(bytes.Trim(buf, "\x00")))
 }

--- a/metriks/distribution_test.go
+++ b/metriks/distribution_test.go
@@ -1,0 +1,35 @@
+package metriks
+
+import (
+	"bytes"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDistribution(t *testing.T) {
+	pc, err := net.ListenPacket("udp", ":10000")
+	require.NoError(t, err)
+	defer pc.Close()
+
+	msgs := make(chan []byte)
+	go func() {
+		buf := make([]byte, 1024)
+		_, _, err := pc.ReadFrom(buf)
+		require.NoError(t, err)
+		msgs <- buf
+		close(msgs)
+	}()
+
+	require.NoError(t, initDistribution(pc.LocalAddr().String(), "testing", []string{"a:1"}))
+	SetDistributionErrorHandler(func(err error) {
+		assert.NoError(t, err)
+	})
+
+	Distribution("some_metric", 12.0, L("b", "c"))
+
+	buf := <-msgs
+	assert.Equal(t, "some_metric.some_metric:12|d|#a:1,b:c", string(bytes.Trim(buf, "\x00")))
+}

--- a/metriks/metriks.go
+++ b/metriks/metriks.go
@@ -24,7 +24,7 @@ func InitTags(serviceName string, conf Config, extraTags []string) error {
 		return nil
 	}
 
-	sink, err := createDatadogSink(conf.StatsdAddr(), "", conf.Tags, extraTags)
+	sink, err := createDatadogSink(conf.StatsdAddr(), "", serviceName, conf.Tags, extraTags)
 	if err != nil {
 		return err
 	}
@@ -57,7 +57,7 @@ func InitWithURL(serviceName string, endpoint string) (metrics.MetricSink, error
 	var sink metrics.MetricSink
 	switch u.Scheme {
 	case "datadog":
-		sink, err = createDatadogSink(u.Host, hostname, map[string]string{}, u.Query()["tag"])
+		sink, err = createDatadogSink(u.Host, hostname, serviceName, map[string]string{}, u.Query()["tag"])
 	case "discard", "":
 		sink = &metrics.BlackholeSink{}
 	default:
@@ -86,8 +86,8 @@ func InitWithSink(serviceName string, sink metrics.MetricSink) error {
 	return nil
 }
 
-func createDatadogSink(url string, name string, tags map[string]string, extraTags []string) (metrics.MetricSink, error) {
-	sink, err := datadog.NewDogStatsdSink(url, name)
+func createDatadogSink(url, hostname, serviceName string, tags map[string]string, extraTags []string) (metrics.MetricSink, error) {
+	sink, err := datadog.NewDogStatsdSink(url, hostname)
 	if err != nil {
 		return nil, err
 	}
@@ -104,7 +104,7 @@ func createDatadogSink(url string, name string, tags map[string]string, extraTag
 	}
 
 	sink.SetTags(ddTags)
-	if err := initDistribution(url, name, ddTags); err != nil {
+	if err := initDistribution(url, serviceName, ddTags); err != nil {
 		return nil, errors.Wrap(err, "failed to initialize the datadog statsd client")
 	}
 	return sink, nil

--- a/metriks/metriks.go
+++ b/metriks/metriks.go
@@ -104,7 +104,9 @@ func createDatadogSink(url string, name string, tags map[string]string, extraTag
 	}
 
 	sink.SetTags(ddTags)
-
+	if err := initDistribution(url, name, ddTags); err != nil {
+		return nil, errors.Wrap(err, "failed to initialize the datadog statsd client")
+	}
 	return sink, nil
 }
 


### PR DESCRIPTION
fixes: https://github.com/netlify/netlify-commons/issues/208

I decided to do this for only the datadog sink because I think it is where it is most useful. It means other sinks will throw this data away.

Also, yes it is icky global where concurrent invocations would be..odd. We could fix this with some locking but I thought the risk was low enough to not worry about that. Part of me was thinking of storing the `statsd` globally but the other supporting values (e.g. default tags, service name) would have to go with it. If we decide to cut the metrics package we can reconsider this whole thing.