### PR TITLE
make a persistent gauge

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.14.x", "1.15.x", "1.16.x"]
+        go: ["1.15.x", "1.16.x"]
     steps:
       - uses: actions/checkout@master
       - uses: actions/setup-go@v1

--- a/metriks/gauge.go
+++ b/metriks/gauge.go
@@ -2,7 +2,6 @@ package metriks
 
 import (
 	"context"
-	"fmt"
 	"sync/atomic"
 	"time"
 
@@ -107,7 +106,6 @@ func NewScheduledGaugeWithDuration(name string, dur time.Duration, cb func() int
 		ScheduledExecutor: util.NewScheduledExecutor(dur, func() {
 			v := cb()
 			Gauge(name, float32(v), tags...)
-			fmt.Println("sent the value?")
 		}),
 	}
 	g.Start()

--- a/metriks/gauge.go
+++ b/metriks/gauge.go
@@ -1,0 +1,77 @@
+package metriks
+
+import (
+	"context"
+	"sync/atomic"
+	"time"
+
+	"github.com/armon/go-metrics"
+)
+
+const (
+	defaultGaugeDuration = time.Second * 10
+)
+
+type PersistentGauge struct {
+	name  string
+	value int32
+	tags  []metrics.Label
+
+	ticker *time.Ticker
+	cancel context.CancelFunc
+	dur    time.Duration
+}
+
+func (g *PersistentGauge) Set(value int32) int32 {
+	v := atomic.SwapInt32(&g.value, value)
+	g.report(value)
+	return v
+}
+
+func (g *PersistentGauge) Inc() int32 {
+	v := atomic.AddInt32(&g.value, 1)
+	g.report(v)
+	return v
+}
+func (g *PersistentGauge) Dec() int32 {
+	v := atomic.AddInt32(&g.value, -1)
+	g.report(v)
+	return v
+}
+
+func (g *PersistentGauge) report(v int32) {
+	Gauge(g.name, float32(v), g.tags...)
+	g.ticker.Reset(g.dur)
+}
+
+func (g *PersistentGauge) start(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-g.ticker.C:
+			g.report(g.value)
+		}
+	}
+}
+
+func (g *PersistentGauge) stop() {
+	g.cancel()
+}
+
+func NewGauge(name string, tags ...metrics.Label) *PersistentGauge {
+	return newGauge(name, tags, defaultGaugeDuration)
+}
+
+func newGauge(name string, tags []metrics.Label, dur time.Duration) *PersistentGauge {
+	ctx, cancel := context.WithCancel(context.Background())
+	g := PersistentGauge{
+		name:   name,
+		tags:   tags,
+		ticker: time.NewTicker(dur),
+		cancel: cancel,
+		dur:    dur,
+	}
+	go g.start(ctx)
+	return &g
+}

--- a/metriks/gauge.go
+++ b/metriks/gauge.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	defaultGaugeDuration = time.Second * 10
+	defaultGaugeDuration = time.Second * 5
 )
 
 // PersistentGauge will report on an interval the value to the metrics collector.
@@ -31,6 +31,7 @@ type PersistentGauge struct {
 func (g *PersistentGauge) Set(value int32) int32 {
 	v := atomic.SwapInt32(&g.value, value)
 	g.report(value)
+
 	return v
 }
 

--- a/metriks/gauge_test.go
+++ b/metriks/gauge_test.go
@@ -12,48 +12,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGauge(t *testing.T) {
-	pc, err := net.ListenPacket("udp", ":10000")
-	require.NoError(t, err)
-	defer pc.Close()
-
-	g := NewGaugeWithDuration("some_gauge", []metrics.Label{L("a", "b")}, time.Second)
+func TestPersistentGauge(t *testing.T) {
+	g := NewPersistentGaugeWithDuration("some_gauge", time.Second, L("a", "b"))
 	defer g.Stop()
 
-	var actualVals []string
-	done := make(chan struct{})
-	go func() {
-		for len(actualVals) != 4 {
-			buf := make([]byte, 1024)
-			_, _, err := pc.ReadFrom(buf)
-			require.NoError(t, err)
-			for _, p := range strings.Split(string(bytes.Trim(buf, "\x00")), "\n") {
-				if p != "" {
-					actualVals = append(actualVals, p)
-				}
-			}
-		}
-		close(done)
-	}()
-
-	sink, err := metrics.NewStatsdSink(pc.LocalAddr().String())
-	require.NoError(t, err)
-	defer sink.Shutdown()
-
-	cfg := metrics.DefaultConfig("test")
-	cfg.EnableHostname = false
-	cfg.EnableRuntimeMetrics = false
-	metrics.NewGlobal(cfg, sink)
+	res := setupStatsDSink(t)
 
 	assert.EqualValues(t, 1, g.Inc())
 	assert.EqualValues(t, 0, g.Dec())
 	assert.EqualValues(t, 0, g.Set(10))
-
-	select {
-	case <-done:
-	case <-time.After(time.Second * 10):
-		assert.Fail(t, "failed to get a metric in time")
-	}
 
 	expectedValues := []string{
 		// these values should be reported everytime we make a call
@@ -63,5 +30,80 @@ func TestGauge(t *testing.T) {
 		// this value should be reported after an interval
 		"test.some_gauge.b:10.000000|g",
 	}
-	assert.Equal(t, expectedValues, actualVals)
+
+	for i := 0; i < 4; i++ {
+		select {
+		case msg := <-res:
+			assert.Equal(t, expectedValues[i], msg)
+		case <-time.After(time.Second * 10):
+			assert.Fail(t, "failed to get a metric in time")
+		}
+	}
+}
+
+func TestScheduledGauge(t *testing.T) {
+	var callCount int32
+	cb := func() int32 {
+		t.Log("here")
+		callCount++
+		return callCount
+	}
+
+	g := NewScheduledGaugeWithDuration("some_gauge", time.Second, cb, L("a", "b"))
+	defer g.Stop()
+
+	res := setupStatsDSink(t)
+
+	expectedValues := []string{
+		"test.some_gauge.b:1.000000|g",
+		"test.some_gauge.b:2.000000|g",
+	}
+	for i := 0; i < 2; i++ {
+		select {
+		case msg := <-res:
+			t.Log("got", msg)
+			assert.Equal(t, expectedValues[i], msg)
+		case <-time.After(time.Second * 20):
+			require.Fail(t, "failed to get a metric in time")
+		}
+	}
+}
+
+func setupStatsDSink(t *testing.T) <-chan string {
+	pc, err := net.ListenPacket("udp", ":10000")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, pc.Close()) })
+
+	sink, err := metrics.NewStatsdSink(pc.LocalAddr().String())
+	require.NoError(t, err)
+	t.Cleanup(sink.Shutdown)
+
+	cfg := metrics.DefaultConfig("test")
+	cfg.EnableHostname = false
+	cfg.EnableRuntimeMetrics = false
+	_, err = metrics.NewGlobal(cfg, sink)
+	require.NoError(t, err)
+
+	return readValues(t, pc)
+}
+
+func readValues(t *testing.T, pc net.PacketConn) <-chan string {
+	res := make(chan string)
+	go func() {
+		for {
+			buf := make([]byte, 512)
+			_, _, err := pc.ReadFrom(buf)
+			if err != nil {
+				close(res)
+				return
+			}
+			for _, p := range strings.Split(string(bytes.Trim(buf, "\x00")), "\n") {
+				t.Log("got msg off socket", p)
+				if p != "" {
+					res <- p
+				}
+			}
+		}
+	}()
+	return res
 }

--- a/metriks/gauge_test.go
+++ b/metriks/gauge_test.go
@@ -44,7 +44,6 @@ func TestPersistentGauge(t *testing.T) {
 func TestScheduledGauge(t *testing.T) {
 	var callCount int32
 	cb := func() int32 {
-		t.Log("here")
 		callCount++
 		return callCount
 	}
@@ -61,7 +60,6 @@ func TestScheduledGauge(t *testing.T) {
 	for i := 0; i < 2; i++ {
 		select {
 		case msg := <-res:
-			t.Log("got", msg)
 			assert.Equal(t, expectedValues[i], msg)
 		case <-time.After(time.Second * 20):
 			require.Fail(t, "failed to get a metric in time")
@@ -98,7 +96,6 @@ func readValues(t *testing.T, pc net.PacketConn) <-chan string {
 				return
 			}
 			for _, p := range strings.Split(string(bytes.Trim(buf, "\x00")), "\n") {
-				t.Log("got msg off socket", p)
 				if p != "" {
 					res <- p
 				}

--- a/metriks/gauge_test.go
+++ b/metriks/gauge_test.go
@@ -17,8 +17,8 @@ func TestGauge(t *testing.T) {
 	require.NoError(t, err)
 	defer pc.Close()
 
-	g := newGauge("some_gauge", []metrics.Label{L("a", "b")}, time.Second)
-	defer g.stop()
+	g := NewGaugeWithDuration("some_gauge", []metrics.Label{L("a", "b")}, time.Second)
+	defer g.Stop()
 
 	var actualVals []string
 	done := make(chan struct{})

--- a/metriks/gauge_test.go
+++ b/metriks/gauge_test.go
@@ -1,0 +1,67 @@
+package metriks
+
+import (
+	"bytes"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/armon/go-metrics"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGauge(t *testing.T) {
+	pc, err := net.ListenPacket("udp", ":10000")
+	require.NoError(t, err)
+	defer pc.Close()
+
+	g := newGauge("some_gauge", []metrics.Label{L("a", "b")}, time.Second)
+	defer g.stop()
+
+	var actualVals []string
+	done := make(chan struct{})
+	go func() {
+		for len(actualVals) != 4 {
+			buf := make([]byte, 1024)
+			_, _, err := pc.ReadFrom(buf)
+			require.NoError(t, err)
+			for _, p := range strings.Split(string(bytes.Trim(buf, "\x00")), "\n") {
+				if p != "" {
+					actualVals = append(actualVals, p)
+				}
+			}
+		}
+		close(done)
+	}()
+
+	sink, err := metrics.NewStatsdSink(pc.LocalAddr().String())
+	require.NoError(t, err)
+	defer sink.Shutdown()
+
+	cfg := metrics.DefaultConfig("test")
+	cfg.EnableHostname = false
+	cfg.EnableRuntimeMetrics = false
+	metrics.NewGlobal(cfg, sink)
+
+	assert.EqualValues(t, 1, g.Inc())
+	assert.EqualValues(t, 0, g.Dec())
+	assert.EqualValues(t, 0, g.Set(10))
+
+	select {
+	case <-done:
+	case <-time.After(time.Second * 10):
+		assert.Fail(t, "failed to get a metric in time")
+	}
+
+	expectedValues := []string{
+		// these values should be reported everytime we make a call
+		"test.some_gauge.b:1.000000|g",
+		"test.some_gauge.b:0.000000|g",
+		"test.some_gauge.b:10.000000|g",
+		// this value should be reported after an interval
+		"test.some_gauge.b:10.000000|g",
+	}
+	assert.Equal(t, expectedValues, actualVals)
+}

--- a/metriks/metriks.go
+++ b/metriks/metriks.go
@@ -97,10 +97,8 @@ func createDatadogSink(url string, name string, tags map[string]string, extraTag
 		ddTags = append(ddTags, fmt.Sprintf("%s:%s", k, v))
 	}
 
-	if extraTags != nil {
-		for _, t := range extraTags {
-			ddTags = append(ddTags, t)
-		}
+	for _, t := range extraTags {
+		ddTags = append(ddTags, t)
 	}
 
 	sink.SetTags(ddTags)


### PR DESCRIPTION
In a handful of services we've needed a gauge that would report on some scheduled timer. This does that so that we can consistently report sparse gauge values to datadog