### PR TITLE
build a test logger

### DIFF
--- a/router/router_test.go
+++ b/router/router_test.go
@@ -92,7 +92,7 @@ func TestTracing(t *testing.T) {
 	r.Post("/def/ghi", noop)
 	r.Put("/asdf/", noop)
 	r.Route("/sub", func(r Router) {
-		r.Get("/path", noop) // func(w http.ResponseWriter, r *http.Request) error { fmt.Println("!!!!!"); return nil })
+		r.Get("/path", noop)
 	})
 
 	scenes := map[string]struct {

--- a/testutil/logger.go
+++ b/testutil/logger.go
@@ -11,6 +11,12 @@ import (
 // Opt is a function that will modify the logger used
 type Opt func(l *logrus.Logger)
 
+// TL will build and return a test logger
+func TL(t *testing.T, opts ...Opt) *logrus.Entry {
+	l, _ := TestLogger(t, opts...)
+	return l
+}
+
 // TestLogger will build a logger that is useful for debugging
 // it respects levels configured by the 'LOG_LEVEL' env var.
 // It takes opt functions to modify the logger used

--- a/testutil/logger.go
+++ b/testutil/logger.go
@@ -1,0 +1,59 @@
+package testutil
+
+import (
+	"os"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+)
+
+// Opt is a function that will modify the logger used
+type Opt func(l *logrus.Logger)
+
+// TestLogger will build a logger that is useful for debugging
+// it respects levels configured by the 'LOG_LEVEL' env var.
+// It takes opt functions to modify the logger used
+func TestLogger(t *testing.T, opts ...Opt) (*logrus.Entry, *test.Hook) {
+	l := logrus.New()
+	l.SetOutput(testLogWrapper{t})
+	hook := test.NewLocal(l)
+	l.SetReportCaller(true)
+	if ll := os.Getenv("LOG_LEVEL"); ll != "" {
+		level, err := logrus.ParseLevel(ll)
+		if err != nil {
+			t.Logf("Error parsing the log level env var (%s), defaulting to info", ll)
+			level = logrus.InfoLevel
+		}
+		l.SetLevel(level)
+	}
+
+	for _, o := range opts {
+		o(l)
+	}
+
+	return l.WithField("test", t.Name()), hook
+}
+
+type testLogWrapper struct {
+	t *testing.T
+}
+
+func (w testLogWrapper) Write(p []byte) (n int, err error) {
+	w.t.Log(string(p))
+	return len(p), nil
+}
+
+// OptSetLevel will override the env var used to configre the logger
+func OptSetLevel(lvl logrus.Level) Opt {
+	return func(l *logrus.Logger) {
+		l.SetLevel(lvl)
+	}
+}
+
+// OptReportCaller will override the reporting of the calling function info
+func OptReportCaller(b bool) Opt {
+	return func(l *logrus.Logger) {
+		l.SetReportCaller(b)
+	}
+}

--- a/testutil/logger_test.go
+++ b/testutil/logger_test.go
@@ -1,0 +1,44 @@
+package testutil
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoggerWrapper(t *testing.T) {
+	tl, h := TestLogger(t)
+	tl.Info("this is a test")
+	assert.Len(t, h.Entries, 1)
+	assert.Equal(t, "this is a test", h.Entries[0].Message)
+	assert.Equal(t, "TestLoggerWrapper", h.Entries[0].Data["test"])
+}
+
+func TestLogWrapperLevel(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		expected []string
+	}{
+		{desc: "DEBUG", expected: []string{"debug", "info", "warn", "error"}},
+		{desc: "NONSENSE", expected: []string{"info", "warn", "error"}},
+		{desc: "INFO", expected: []string{"info", "warn", "error"}},
+		{desc: "ERROR", expected: []string{"error"}},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			os.Setenv("LOG_LEVEL", tC.desc)
+			tl, h := TestLogger(t)
+			tl.Debug("debug")
+			tl.Info("info")
+			tl.Warn("warn")
+			tl.Error("error")
+
+			logged := []string{}
+			for _, entry := range h.Entries {
+				logged = append(logged, entry.Message)
+			}
+			assert.Equal(t, tC.expected, logged)
+		})
+	}
+}

--- a/tracing/req_tracer_test.go
+++ b/tracing/req_tracer_test.go
@@ -1,7 +1,6 @@
 package tracing
 
 import (
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -31,7 +30,6 @@ func TestTracerLogging(t *testing.T) {
 	assert.Empty(t, e.Data["referrer"])
 	assert.NotEmpty(t, e.Data["method"])
 	assert.Equal(t, "http://whatever.com/something", e.Data["url"])
-	fmt.Println(e.Data)
 
 	_ = SetLogField(r, "first", "second")
 	SetFinalField(r, "final", "line").Info("should have the final here")
@@ -40,14 +38,12 @@ func TestTracerLogging(t *testing.T) {
 	assert.NotEmpty(t, e.Data["request_id"])
 	assert.Equal(t, "line", e.Data["final"])
 	assert.Equal(t, "second", e.Data["first"])
-	fmt.Println(e.Data)
 
 	rt.Info("Shouldn't have the final line")
 	e = hook.LastEntry()
 	assert.Equal(t, 2, len(e.Data))
 	assert.NotEmpty(t, e.Data["request_id"])
 	assert.Equal(t, "second", e.Data["first"])
-	fmt.Println(e.Data)
 
 	rt.WriteHeader(http.StatusOK)
 	rt.Write([]byte{0, 1, 2, 3})


### PR DESCRIPTION
I was waiting for some humio queries to finish and decided that I'd finally write this. What the goal is to make it easier to inject a logger all over our tests.

There is a lot of
```
func tl(t *testing.T) logrus.FieldLogger {
  return logrus.WithField("test", t.Name())
}
```

And `init` blocks that check for the log level in a variety of forms. This is an effort to have to never copy/paste that code again. While I was there I also added some features I think are nice, but I'm open to removing them. 