### PR TITLE
Fix FakeKafkaConsumer to advance through messages

### DIFF
--- a/kafka/kafkatest/utils.go
+++ b/kafka/kafkatest/utils.go
@@ -125,6 +125,7 @@ func (f *FakeKafkaConsumer) CommitMessage(msg *kafkalib.Message) error {
 func (f *FakeKafkaConsumer) SetInitialOffset(offset int64) error {
 	f.msgMu.Lock()
 	f.offset = offset
+	f.uncommitedOffset = offset
 	f.msgMu.Unlock()
 	return nil
 }
@@ -132,6 +133,7 @@ func (f *FakeKafkaConsumer) SetInitialOffset(offset int64) error {
 func (f *FakeKafkaConsumer) Seek(offset int64) error {
 	f.msgMu.Lock()
 	f.offset = offset
+	f.uncommitedOffset = offset
 	f.msgMu.Unlock()
 	return nil
 }

--- a/kafka/kafkatest/utils.go
+++ b/kafka/kafkatest/utils.go
@@ -33,13 +33,13 @@ func KafkaPipe(log logrus.FieldLogger) (*FakeKafkaConsumer, *FakeKafkaProducer) 
 }
 
 type FakeKafkaConsumer struct {
-	messages         []*kafkalib.Message
-	msgMu            sync.Mutex
-	offset           int64
-	uncommitedOffset int64
-	notify           chan struct{}
-	commits          chan *kafkalib.Message
-	log              logrus.FieldLogger
+	messages   []*kafkalib.Message
+	msgMu      sync.Mutex
+	offset     int64
+	readOffset int64
+	notify     chan struct{}
+	commits    chan *kafkalib.Message
+	log        logrus.FieldLogger
 }
 
 type FakeKafkaProducer struct {
@@ -64,12 +64,12 @@ func (f *FakeKafkaProducer) Close() error {
 
 func NewFakeKafkaConsumer(log logrus.FieldLogger, distri <-chan *kafkalib.Message) *FakeKafkaConsumer {
 	r := &FakeKafkaConsumer{
-		messages:         make([]*kafkalib.Message, 0),
-		offset:           0,
-		uncommitedOffset: 0,
-		notify:           make(chan struct{}),
-		log:              log,
-		commits:          make(chan *kafkalib.Message, 1000),
+		messages:   make([]*kafkalib.Message, 0),
+		offset:     0,
+		readOffset: 0,
+		notify:     make(chan struct{}),
+		log:        log,
+		commits:    make(chan *kafkalib.Message, 1000),
 	}
 
 	go func() {
@@ -88,12 +88,12 @@ func NewFakeKafkaConsumer(log logrus.FieldLogger, distri <-chan *kafkalib.Messag
 func (f *FakeKafkaConsumer) FetchMessage(ctx context.Context) (*kafkalib.Message, error) {
 	for {
 		f.msgMu.Lock()
-		if int64(len(f.messages)) > f.uncommitedOffset {
-			f.log.WithField("offset", f.uncommitedOffset).Trace("offering message")
-			msg := f.messages[f.uncommitedOffset]
+		if int64(len(f.messages)) > f.readOffset {
+			f.log.WithField("offset", f.readOffset).Trace("offering message")
+			msg := f.messages[f.readOffset]
 			f.msgMu.Unlock()
 
-			f.uncommitedOffset = f.uncommitedOffset + 1
+			f.readOffset = f.readOffset + 1
 			return msg, nil
 		}
 		f.msgMu.Unlock()
@@ -111,7 +111,6 @@ func (f *FakeKafkaConsumer) CommitMessage(msg *kafkalib.Message) error {
 	f.log.WithField("offset", msg.TopicPartition.Offset).Trace("commiting message...")
 	if int64(msg.TopicPartition.Offset) > f.offset {
 		f.offset = int64(msg.TopicPartition.Offset)
-		f.uncommitedOffset = f.offset
 		f.log.WithField("offset", f.offset).Trace("set new offset")
 	}
 	select {
@@ -125,15 +124,14 @@ func (f *FakeKafkaConsumer) CommitMessage(msg *kafkalib.Message) error {
 func (f *FakeKafkaConsumer) SetInitialOffset(offset int64) error {
 	f.msgMu.Lock()
 	f.offset = offset
-	f.uncommitedOffset = offset
+	f.readOffset = offset
 	f.msgMu.Unlock()
 	return nil
 }
 
 func (f *FakeKafkaConsumer) Seek(offset int64) error {
 	f.msgMu.Lock()
-	f.offset = offset
-	f.uncommitedOffset = offset
+	f.readOffset = offset
 	f.msgMu.Unlock()
 	return nil
 }

--- a/kafka/kafkatest/utils_test.go
+++ b/kafka/kafkatest/utils_test.go
@@ -21,10 +21,13 @@ func TestFakeKafkaProducer_WaitForKey(t *testing.T) {
 		Key:   []byte(`key1`),
 		Value: []byte(`val1`),
 	})
+	require.NoError(t, err)
+
 	err = p.Produce(ctx, &kafkalib.Message{
 		Key:   []byte(`key2`),
 		Value: []byte(`val2`),
 	})
+	require.NoError(t, err)
 
 	msg, err := c.FetchMessage(ctx)
 	require.NoError(t, err)


### PR DESCRIPTION
**Summary**
I seems the the `FakeKafkaConsumer` will only advance to read the next message if you commit the offset, which isn't how a real consumer is expected to operate.

I added an `uncommitedOffset` to the consumer which will advance after every `FetchMessage`.