### PR TITLE
feat: allow setting initial delay & custom ticker in the scheduled executor

### DIFF
--- a/util/scheduled_executor.go
+++ b/util/scheduled_executor.go
@@ -112,9 +112,11 @@ func (s *scheduledExecutor) poll() {
 		select {
 		case <-s.done:
 			delay.Stop()
+			delay = nil
 			return
 		case <-delay.C:
 			delay.Stop()
+			delay = nil
 		}
 	}
 

--- a/util/scheduled_executor.go
+++ b/util/scheduled_executor.go
@@ -10,32 +10,66 @@ type ScheduledExecutor interface {
 	Stop()
 }
 
+type CustomTicker interface {
+	Stop()
+	C() <-chan time.Time
+}
+
+type Option func(*scheduledExecutor)
+
+type defaultTicker struct {
+	*time.Ticker
+}
+
+func (d *defaultTicker) C() <-chan time.Time {
+	return d.Ticker.C
+}
+
 type scheduledExecutor struct {
-	period             time.Duration
-	cb                 func()
-	isRunning          AtomicBool
-	ticker             *time.Ticker
-	done               chan bool
-	wg                 sync.WaitGroup
-	enableInstantStart bool
+	period       time.Duration
+	cb           func()
+	isRunning    AtomicBool
+	ticker       CustomTicker
+	done         chan bool
+	wg           sync.WaitGroup
+	initialDelay time.Duration
 }
 
 func NewScheduledExecutor(period time.Duration, cb func()) ScheduledExecutor {
 	return &scheduledExecutor{
-		period:    period,
-		cb:        cb,
-		isRunning: NewAtomicBool(false),
-		wg:        sync.WaitGroup{},
+		period:       period,
+		cb:           cb,
+		isRunning:    NewAtomicBool(false),
+		wg:           sync.WaitGroup{},
+		initialDelay: period,
 	}
 }
 
-func NewExecutorWithInstantStart(period time.Duration, cb func()) ScheduledExecutor {
-	return &scheduledExecutor{
-		period:             period,
-		cb:                 cb,
-		isRunning:          NewAtomicBool(false),
-		wg:                 sync.WaitGroup{},
-		enableInstantStart: true,
+func NewScheduledExecutorWithOpts(period time.Duration, cb func(), options ...Option) ScheduledExecutor {
+	s := &scheduledExecutor{
+		period:       period,
+		cb:           cb,
+		isRunning:    NewAtomicBool(false),
+		wg:           sync.WaitGroup{},
+		initialDelay: period,
+	}
+
+	for _, opt := range options {
+		opt(s)
+	}
+
+	return s
+}
+
+func WithInitialDelay(initialDelay time.Duration) Option {
+	return func(s *scheduledExecutor) {
+		s.initialDelay = initialDelay
+	}
+}
+
+func WithCustomTicker(ticker CustomTicker) Option {
+	return func(s *scheduledExecutor) {
+		s.ticker = ticker
 	}
 }
 
@@ -44,7 +78,7 @@ func (s *scheduledExecutor) Start() {
 		return
 	}
 
-	s.ticker = time.NewTicker(s.period)
+	s.ticker = CustomTicker(&defaultTicker{time.NewTicker(s.period)})
 	s.done = make(chan bool)
 	s.wg.Add(1)
 
@@ -66,23 +100,13 @@ func (s *scheduledExecutor) Stop() {
 
 func (s *scheduledExecutor) poll() {
 	defer s.wg.Done()
-	if s.enableInstantStart {
-		for ; true; <-s.ticker.C {
-			select {
-			case <-s.done:
-				return
-			default:
-			}
-			s.cb()
+	time.Sleep(s.initialDelay)
+	for ; true; <-s.ticker.C() {
+		select {
+		case <-s.done:
+			return
+		default:
 		}
-	} else {
-		for {
-			select {
-			case <-s.done:
-				return
-			case <-s.ticker.C:
-				s.cb()
-			}
-		}
+		s.cb()
 	}
 }

--- a/util/scheduled_executor_test.go
+++ b/util/scheduled_executor_test.go
@@ -13,23 +13,23 @@ func TestScheduledExecutor(t *testing.T) {
 		increaseCount := func() {
 			count++
 		}
-		s := NewScheduledExecutor(3*time.Second, increaseCount)
+		s := NewScheduledExecutor(2*time.Second, increaseCount)
 		s.Start()
+		defer s.Stop()
 		assert.Equal(t, 0, count)
-		time.Sleep(3 * time.Second)
+		time.Sleep(2 * time.Second)
 		assert.Equal(t, 1, count)
-		s.Stop()
 	})
-	t.Run("default ticker starts with delay", func(t *testing.T) {
-		var count int
-		increaseCount := func() {
-			count++
-		}
-		s := NewScheduledExecutor(3*time.Second, increaseCount)
-		s.Start()
-		assert.Equal(t, 0, count)
-		time.Sleep(3 * time.Second)
-		assert.Equal(t, 1, count)
-		s.Stop()
-	})
+	// t.Run("default ticker starts with delay", func(t *testing.T) {
+	// 	var count int
+	// 	increaseCount := func() {
+	// 		count++
+	// 	}
+	// 	s := NewScheduledExecutor(3*time.Second, increaseCount)
+	// 	s.Start()
+	// 	assert.Equal(t, 0, count)
+	// 	time.Sleep(3 * time.Second)
+	// 	assert.Equal(t, 1, count)
+	// 	s.Stop()
+	// })
 }

--- a/util/scheduled_executor_test.go
+++ b/util/scheduled_executor_test.go
@@ -13,23 +13,40 @@ func TestScheduledExecutor(t *testing.T) {
 		increaseCount := func() {
 			count++
 		}
-		s := NewScheduledExecutor(2*time.Second, increaseCount)
+		s := NewScheduledExecutor(100*time.Millisecond, increaseCount)
 		s.Start()
 		defer s.Stop()
+		time.Sleep(1 * time.Millisecond)
 		assert.Equal(t, 0, count)
-		time.Sleep(2 * time.Second)
+		time.Sleep(105 * time.Millisecond)
 		assert.Equal(t, 1, count)
 	})
-	// t.Run("default ticker starts with delay", func(t *testing.T) {
-	// 	var count int
-	// 	increaseCount := func() {
-	// 		count++
-	// 	}
-	// 	s := NewScheduledExecutor(3*time.Second, increaseCount)
-	// 	s.Start()
-	// 	assert.Equal(t, 0, count)
-	// 	time.Sleep(3 * time.Second)
-	// 	assert.Equal(t, 1, count)
-	// 	s.Stop()
-	// })
+	t.Run("start with 0 initial delay", func(t *testing.T) {
+		var count int
+		increaseCount := func() {
+			count++
+		}
+		s := NewScheduledExecutorWithOpts(100*time.Millisecond, increaseCount, WithInitialDelay(0))
+		s.Start()
+		defer s.Stop()
+		time.Sleep(1 * time.Millisecond)
+		assert.Equal(t, 1, count)
+		time.Sleep(105 * time.Millisecond)
+		assert.Equal(t, 2, count)
+	})
+	t.Run("start with 50 milliseconds of initial delay", func(t *testing.T) {
+		var count int
+		increaseCount := func() {
+			count++
+		}
+		s := NewScheduledExecutorWithOpts(100*time.Millisecond, increaseCount, WithInitialDelay(50*time.Millisecond))
+		s.Start()
+		defer s.Stop()
+		time.Sleep(1 * time.Millisecond)
+		assert.Equal(t, 0, count)
+		time.Sleep(55 * time.Millisecond)
+		assert.Equal(t, 1, count)
+		time.Sleep(105 * time.Millisecond)
+		assert.Equal(t, 2, count)
+	})
 }

--- a/util/scheduled_executor_test.go
+++ b/util/scheduled_executor_test.go
@@ -1,0 +1,35 @@
+package util
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestScheduledExecutor(t *testing.T) {
+	t.Run("default ticker starts with delay", func(t *testing.T) {
+		var count int
+		increaseCount := func() {
+			count++
+		}
+		s := NewScheduledExecutor(3*time.Second, increaseCount)
+		s.Start()
+		assert.Equal(t, 0, count)
+		time.Sleep(3 * time.Second)
+		assert.Equal(t, 1, count)
+		s.Stop()
+	})
+	t.Run("default ticker starts with delay", func(t *testing.T) {
+		var count int
+		increaseCount := func() {
+			count++
+		}
+		s := NewScheduledExecutor(3*time.Second, increaseCount)
+		s.Start()
+		assert.Equal(t, 0, count)
+		time.Sleep(3 * time.Second)
+		assert.Equal(t, 1, count)
+		s.Stop()
+	})
+}


### PR DESCRIPTION
- adds custom Ticker interface and types to allow users to pass in their own ticker type or specify initial delay (including having the ticker start immediately) 
- should not change/break any existing behavior for scheduled executor (if people are expecting scheduled executor to wait for a duration before executing)