### PR TITLE
feat(instrument): stop returning error with instrument functions

### DIFF
--- a/instrument/global.go
+++ b/instrument/global.go
@@ -36,26 +36,26 @@ func Init(conf Config, log logrus.FieldLogger) error {
 }
 
 // Identify sends an identify type message to a queue to be sent to Segment.
-func Identify(userID string, traits analytics.Traits) error {
-	return GetGlobalClient().Identify(userID, traits)
+func Identify(userID string, traits analytics.Traits) {
+	GetGlobalClient().Identify(userID, traits)
 }
 
 // Track sends a track type message to a queue to be sent to Segment.
-func Track(userID string, event string, properties analytics.Properties) error {
-	return GetGlobalClient().Track(userID, event, properties)
+func Track(userID string, event string, properties analytics.Properties) {
+	GetGlobalClient().Track(userID, event, properties)
 }
 
 // Page sends a page type message to a queue to be sent to Segment.
-func Page(userID string, name string, properties analytics.Properties) error {
-	return GetGlobalClient().Page(userID, name, properties)
+func Page(userID string, name string, properties analytics.Properties) {
+	GetGlobalClient().Page(userID, name, properties)
 }
 
 // Group sends a group type message to a queue to be sent to Segment.
-func Group(userID string, groupID string, traits analytics.Traits) error {
-	return GetGlobalClient().Group(userID, groupID, traits)
+func Group(userID string, groupID string, traits analytics.Traits) {
+	GetGlobalClient().Group(userID, groupID, traits)
 }
 
 // Alias sends an alias type message to a queue to be sent to Segment.
-func Alias(previousID string, userID string) error {
-	return GetGlobalClient().Alias(previousID, userID)
+func Alias(previousID string, userID string) {
+	GetGlobalClient().Alias(previousID, userID)
 }

--- a/instrument/instrument.go
+++ b/instrument/instrument.go
@@ -8,11 +8,11 @@ import (
 )
 
 type Client interface {
-	Identify(userID string, traits analytics.Traits) error
-	Track(userID string, event string, properties analytics.Properties) error
-	Page(userID string, name string, properties analytics.Properties) error
-	Group(userID string, groupID string, traits analytics.Traits) error
-	Alias(previousID string, userID string) error
+	Identify(userID string, traits analytics.Traits)
+	Track(userID string, event string, properties analytics.Properties)
+	Page(userID string, name string, properties analytics.Properties)
+	Group(userID string, groupID string, traits analytics.Traits)
+	Alias(previousID string, userID string)
 }
 
 type segmentClient struct {
@@ -39,42 +39,57 @@ func NewClient(cfg *Config, logger logrus.FieldLogger) (Client, error) {
 	return &segmentClient{inner, logger}, err
 }
 
-func (c segmentClient) Identify(userID string, traits analytics.Traits) error {
-	return c.Client.Enqueue(analytics.Identify{
+func (c segmentClient) Identify(userID string, traits analytics.Traits) {
+	err := c.Client.Enqueue(analytics.Identify{
 		UserId: userID,
 		Traits: traits,
 	})
+	if err != nil {
+		c.log.WithError(err).Info("Failed to send instrument Identify metrics")
+	}
 }
 
-func (c segmentClient) Track(userID string, event string, properties analytics.Properties) error {
-	return c.Client.Enqueue(analytics.Track{
+func (c segmentClient) Track(userID string, event string, properties analytics.Properties) {
+	err := c.Client.Enqueue(analytics.Track{
 		UserId:     userID,
 		Event:      event,
 		Properties: properties,
 	})
+	if err != nil {
+		c.log.WithError(err).Info("Failed to send instrument Track metrics")
+	}
 }
 
-func (c segmentClient) Page(userID string, name string, properties analytics.Properties) error {
-	return c.Client.Enqueue(analytics.Page{
+func (c segmentClient) Page(userID string, name string, properties analytics.Properties) {
+	err := c.Client.Enqueue(analytics.Page{
 		UserId:     userID,
 		Name:       name,
 		Properties: properties,
 	})
+	if err != nil {
+		c.log.WithError(err).Info("Failed to send instrument Page metrics")
+	}
 }
 
-func (c segmentClient) Group(userID string, groupID string, traits analytics.Traits) error {
-	return c.Client.Enqueue(analytics.Group{
+func (c segmentClient) Group(userID string, groupID string, traits analytics.Traits) {
+	err := c.Client.Enqueue(analytics.Group{
 		UserId:  userID,
 		GroupId: groupID,
 		Traits:  traits,
 	})
+	if err != nil {
+		c.log.WithError(err).Info("Failed to send instrument Group metrics")
+	}
 }
 
-func (c segmentClient) Alias(previousID string, userID string) error {
-	return c.Client.Enqueue(analytics.Alias{
+func (c segmentClient) Alias(previousID string, userID string) {
+	err := c.Client.Enqueue(analytics.Alias{
 		PreviousId: previousID,
 		UserId:     userID,
 	})
+	if err != nil {
+		c.log.WithError(err).Info("Failed to send instrument Alias metrics")
+	}
 }
 
 func configureLogger(conf *analytics.Config, log logrus.FieldLogger) {

--- a/instrument/instrument_test.go
+++ b/instrument/instrument_test.go
@@ -22,10 +22,12 @@ func TestLogOnlyClient(t *testing.T) {
 }
 
 func TestMockClient(t *testing.T) {
-	log := testutil.TL(t)
+	log, hook := testutil.TestLogger(t)
 	mock := MockClient{log}
 
-	require.NoError(t, mock.Identify("myuser", analytics.NewTraits().SetName("My User")))
+	mock.Identify("myuser", analytics.NewTraits().SetName("My User"))
+	assert.NotEmpty(t, hook.LastEntry())
+	assert.Contains(t, hook.LastEntry().Message, "Received Identify event")
 }
 
 func TestLogging(t *testing.T) {
@@ -37,6 +39,6 @@ func TestLogging(t *testing.T) {
 
 	client, err := NewClient(&cfg, log.WithField("component", "segment"))
 	require.NoError(t, err)
-	require.NoError(t, client.Identify("myuser", analytics.NewTraits().SetName("My User")))
+	client.Identify("myuser", analytics.NewTraits().SetName("My User"))
 	assert.NotEmpty(t, hook.LastEntry())
 }

--- a/instrument/mock.go
+++ b/instrument/mock.go
@@ -11,45 +11,40 @@ type MockClient struct {
 
 var _ Client = MockClient{}
 
-func (c MockClient) Identify(userID string, traits analytics.Traits) error {
+func (c MockClient) Identify(userID string, traits analytics.Traits) {
 	c.Logger.WithFields(logrus.Fields{
 		"user_id": userID,
 		"traits":  traits,
-	}).Infof("Received Identity event")
-	return nil
+	}).Info("Received Identify event")
 }
 
-func (c MockClient) Track(userID string, event string, properties analytics.Properties) error {
+func (c MockClient) Track(userID string, event string, properties analytics.Properties) {
 	c.Logger.WithFields(logrus.Fields{
 		"user_id":    userID,
 		"event":      event,
 		"properties": properties,
-	}).Infof("Received Track event")
-	return nil
+	}).Info("Received Track event")
 }
 
-func (c MockClient) Page(userID string, name string, properties analytics.Properties) error {
+func (c MockClient) Page(userID string, name string, properties analytics.Properties) {
 	c.Logger.WithFields(logrus.Fields{
 		"user_id":    userID,
 		"name":       name,
 		"properties": properties,
-	}).Infof("Received Page event")
-	return nil
+	}).Info("Received Page event")
 }
 
-func (c MockClient) Group(userID string, groupID string, traits analytics.Traits) error {
+func (c MockClient) Group(userID string, groupID string, traits analytics.Traits) {
 	c.Logger.WithFields(logrus.Fields{
 		"user_id":  userID,
 		"group_id": groupID,
 		"traits":   traits,
-	}).Infof("Received Group event")
-	return nil
+	}).Info("Received Group event")
 }
 
-func (c MockClient) Alias(previousID string, userID string) error {
+func (c MockClient) Alias(previousID string, userID string) {
 	c.Logger.WithFields(logrus.Fields{
 		"previous_id": previousID,
 		"user_id":     userID,
-	}).Infof("Received Alias event")
-	return nil
+	}).Info("Received Alias event")
 }


### PR DESCRIPTION
While using `instrument` in identeer, I realized that I had to do the error check every time I call the tracking.
https://github.com/netlify/identeer/pull/96/files#r602408645
This is not a user friendly shape, and also the user could only do the "logging the failure" really, nothing more. With this PR, netlify-commons will do the logging part for you, so that you can use `instrument` as a one liner.

reference: Segment would return the error with the tracking for the following case, which should be okay to "ignore":

> // The method returns an error if the message queue not be queued, which
> // happens if the client was already closed at the time the method was
> // called or if the message was malformed.

**BREAKING CHANGES:**
Functions with instrument like `instrument.Identify`, `instrument.Track` will no longer return `error`. If you were using this before with the error handling, please remove the error handling.