### PR TITLE
feat: add field for pinned plugin version

### DIFF
--- a/ntoml/netlify_toml.go
+++ b/ntoml/netlify_toml.go
@@ -48,7 +48,8 @@ type BuildConfig struct {
 }
 
 type Plugin struct {
-	Package string `toml:"package" json:"package" yaml:"package"`
+	Package       string `toml:"package" json:"package" yaml:"package"`
+	PinnedVersion string `toml:"pinned_version" json:"pinned_version" yaml:"pinned_version"`
 }
 
 type DeployContext struct {


### PR DESCRIPTION
Adds a field to the netlify plugin configuration for the pinned plugin version. Part of https://github.com/netlify/buildbot/issues/1269
