### PR TITLE
Upgrade the minimum golang version required to build(v1.15)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -56,4 +56,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
 )
 
-go 1.14
+go 1.15


### PR DESCRIPTION
I noticed netlify-commons sets go 1.14 as the minimum version, however the project has v1.15 features and therefore won't allow one to build with v1.14. Our CI also builds with only v1.15 and v1.16

Here is an example of a feature used and only available in v1.15:

The Ticker.Reset function used here -  https://github.com/netlify/netlify-commons/blob/c1a004d0f8e6998d8058e5cc68a0606ed5e67876/metriks/gauge.go#L54 was introduced in golang v1.15 and therefore won’t work when one builds with 1.14

BREAKING CHANGES:
n/a