### PR TITLE
feat: add AllEnabledFlagsUser to featureflag

### DIFF
--- a/featureflag/featureflag.go
+++ b/featureflag/featureflag.go
@@ -82,7 +82,11 @@ func (c *ldClient) VariationUser(key string, defaultVal string, user ld.User) st
 }
 
 func (c *ldClient) AllEnabledFlags(key string) []string {
-	res := c.AllFlagsState(ld.NewUser(key), ld.DetailsOnlyForTrackedFlags)
+	return c.AllEnabledFlagsUser(key, ld.NewUser(key))
+}
+
+func (c *ldClient) AllEnabledFlagsUser(key string, user ld.User) []string {
+	res := c.AllFlagsState(user, ld.DetailsOnlyForTrackedFlags)
 	flagMap := res.ToValuesMap()
 
 	var flags []string


### PR DESCRIPTION
This PR adds a `AllEnabledFlagsUser` method to the `featureflag` package, which does the same as `AllEnabledFlags` but accepts a LD user as an argument. It follows the same pattern as `Enabled`/`EnabledUser` and `Variation`/`VariationUser`.

We'd need this in buildbot as part of https://github.com/netlify/buildbot/issues/1395.
