### PR TITLE
Cancel Http safe client requests before getting connection 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ test:
 integration-test:
 	docker-compose -f Dockercompose.test.yml up --build --abort-on-container-exit --always-recreate-deps
 	docker-compose -f Dockercompose.test.yml down --volumes
-	
+
 clean:
 	docker-compose -f Dockercompose.test.yml rm -f
 

--- a/http/http.go
+++ b/http/http.go
@@ -52,9 +52,8 @@ func (no noLocalTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 	ctx, cancel := context.WithCancel(req.Context())
 
 	ctx = httptrace.WithClientTrace(ctx, &httptrace.ClientTrace{
-		GotConn: func(info httptrace.GotConnInfo) {
-			addr := info.Conn.RemoteAddr().String()
-			host, _, err := net.SplitHostPort(addr)
+		GetConn: func(hostPort string) {
+			host, _, err := net.SplitHostPort(hostPort)
 			if err != nil {
 				cancel()
 				no.errlog.WithError(err).Error("Cancelled request due to error in address parsing")

--- a/http/http_test.go
+++ b/http/http_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIsPrivateIP(t *testing.T) {
@@ -44,15 +45,16 @@ func TestSafeHTTPClient(t *testing.T) {
 
 	// It blocks the local IP.
 	_, err = client.Get(ts.URL)
-	assert.NotNil(t, err)
+	require.NotNil(t, err)
 
 	// It blocks localhost.
 	_, err = client.Get("http://localhost:" + tsURL.Port())
-	assert.NotNil(t, err)
+	require.NotNil(t, err)
 
 	// It works when reusing pooled connections.
 	for i := 0; i < 50; i++ {
-		_, err = client.Get("http://localhost:" + tsURL.Port())
+		res, err := client.Get("http://localhost:" + tsURL.Port())
+		assert.Nil(t, res)
 		assert.NotNil(t, err)
 	}
 


### PR DESCRIPTION
Current CI is failing due to
```
  http_test.go:56: 
        	Error Trace:	http_test.go:56
        	Error:      	Expected value not to be nil.
        	Test:       	TestSafeHTTPClient
```

This is because we're using `httptrace` to hook to when the http transport successfully retrieves a new or idle connection. Connection pooling [happens async](https://cs.opensource.google/go/go/+/master:src/net/http/transport.go;l=1351;drc=refs%2Ftags%2Fgo1.17.2;bpv=1;bpt=1), which means there's a race between cancelling the context and retrieving a valid connection, which sometimes causes the transport *not to fail*. 

Not only that, connections are also [dialed and returned to the pool asynchronously](https://cs.opensource.google/go/go/+/master:src/net/http/transport.go;drc=refs%2Ftags%2Fgo1.17.2;bpv=1;bpt=1;l=890). Since the test does 50 consecutive requests so quickly, it's not able to reuse the idle connections as it never finds one.

This PR makes it so that connections are not even fetched from the pool and unifies behaviour between HTTP/1.1 and HTTP/2, which handles GotConn differently, but [GetConn the same way](https://cs.opensource.google/go/go/+/master:src/net/http/transport.go;l=1333;drc=refs%2Ftags%2Fgo1.17.2).

In addition, this PR solves a race condition happening locally to me, where the a gauge was sometimes not able to cancel its internal context before the underlying data sink was, causing writes to the internal sink queue (channel) which was closed (thanks @mrdg for the solution to this)