### PR TITLE
feat: add URLParam function to router

### DIFF
--- a/router/router.go
+++ b/router/router.go
@@ -52,6 +52,9 @@ type Router interface {
 	Mount(pattern string, h http.Handler)
 
 	ServeHTTP(http.ResponseWriter, *http.Request)
+
+	// Returns the value of a URL parameter
+	URLParam(*http.Request, string) string
 }
 
 // New creates a router with sensible defaults (xff, request id, cors)
@@ -149,6 +152,11 @@ func (r *chiWrapper) Mount(pattern string, h http.Handler) {
 		})
 	}
 	r.chi.Mount(pattern, h)
+}
+
+// Returns the value of a URL parameter
+func (r *chiWrapper) URLParam(req *http.Request, name string) string {
+	return chi.URLParam(req, name)
 }
 
 // =======================================

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -147,6 +147,21 @@ func TestVersionHeader(t *testing.T) {
 	}
 }
 
+func TestURLParam(t *testing.T) {
+	r := New(logrus.WithField("test", t.Name()), OptEnableTracing("some-service"))
+
+	r.Get("/objects/{objectId}", func(w http.ResponseWriter, req *http.Request) error {
+		w.Write([]byte(r.URLParam(req, "objectId")))
+		w.WriteHeader(http.StatusOK)
+		return nil
+	})
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest("GET", "/objects/some-object", nil))
+	assert.Equal(t, []byte("some-object"), rec.Body.Bytes())
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
 func do(t *testing.T, opts []Option, svcName, path string, handler APIHandler, req *http.Request) *httptest.ResponseRecorder {
 	if opts == nil {
 		opts = []Option{}


### PR DESCRIPTION
I wanted to define a route like `/route/{param}` and extract the value of `param` in the handler. I didn't find a built-in way of extracting the value of URL parameters with the router, so this PR adds a function that wraps the `URLParam` function from `chi`.

_Example usage:_

```go
r.Get("/jobs/{jobId}", func(w http.ResponseWriter, req *http.Request) error {
  jobId := r.URLParam(req, "jobId")
  
  doSomething(jobId)
  
  w.WriteHeader(http.StatusOK)

  return nil
})
```

Apologies if it's already possible to do this with the router and I completely missed it, in which case feel free to close the PR.