### PR TITLE
Must read value with atomic

### DIFF
--- a/metriks/gauge.go
+++ b/metriks/gauge.go
@@ -64,7 +64,7 @@ func (g *PersistentGauge) start(ctx context.Context) {
 			g.wg.Done()
 			return
 		case <-g.ticker.C:
-			g.report(g.value)
+			g.report(atomic.LoadInt32(&g.value))
 		}
 	}
 }


### PR DESCRIPTION
The race detector picked this up, we must read value with atomic as well.

```

WARNING: DATA RACE
Read at 0x00c000524eb0 by goroutine 7:
  github.com/netlify/netlify-commons/metriks.(*PersistentGauge).start()
      .../work/src/github.com/netlify/netlify-commons/metriks/gauge.go:67 +0x7a
  github.com/netlify/netlify-commons/metriks.NewPersistentGaugeWithDuration·dwrap·1()
      .../work/src/github.com/netlify/netlify-commons/metriks/gauge.go:94 +0x58

Previous write at 0x00c000524eb0 by goroutine 8:
  sync/atomic.SwapInt32()
      .../1.17.1/go/src/runtime/race_amd64.s:280 +0xb
  sync/atomic.SwapInt32()
      <autogenerated>:1 +0x1a
  github.com/netlify/netlify-commons/metriks.TestPersistentGauge()
      .../work/src/github.com/netlify/netlify-commons/metriks/gauge_test.go:23 +0x1e4
  testing.tRunner()
      .../1.17.1/go/src/testing/testing.go:1259 +0x22f
  testing.(*T).Run·dwrap·21()
      .../1.17.1/go/src/testing/testing.go:1306 +0x47

Goroutine 7 (running) created at:
  github.com/netlify/netlify-commons/metriks.NewPersistentGaugeWithDuration()
      .../work/src/github.com/netlify/netlify-commons/metriks/gauge.go:94 +0x250
  github.com/netlify/netlify-commons/metriks.TestPersistentGauge()
      .../work/src/github.com/netlify/netlify-commons/metriks/gauge_test.go:16 +0xdb
  testing.tRunner()
      .../1.17.1/go/src/testing/testing.go:1259 +0x22f
  testing.(*T).Run·dwrap·21()
      .../1.17.1/go/src/testing/testing.go:1306 +0x47

Goroutine 8 (running) created at:
  testing.(*T).Run()
      .../1.17.1/go/src/testing/testing.go:1306 +0x726
  testing.runTests.func1()
      .../1.17.1/go/src/testing/testing.go:1598 +0x99
  testing.tRunner()
      .../1.17.1/go/src/testing/testing.go:1259 +0x22f
  testing.runTests()
      .../1.17.1/go/src/testing/testing.go:1596 +0x7ca
  testing.(*M).Run()
      .../1.17.1/go/src/testing/testing.go:1504 +0x9d1
  main.main()
      _testmain.go:59 +0x22b

```