### PR TITLE
Add service tag to metrics and traces

### DIFF
--- a/metriks/metriks_test.go
+++ b/metriks/metriks_test.go
@@ -38,11 +38,15 @@ func TestDatadogSink(t *testing.T) {
 
 	Inc("test_counter", 1)
 
-	expectedMsg := "test.test_counter:1|c|#app:edge-state,env:test"
-	buf := make([]byte, len(expectedMsg))
-	_, _, err = l.ReadFrom(buf)
+	expectedMsg := "test.test_counter:1|c|#app:edge-state,env:test,service:test"
+
+	var readBytes int
+	buf := make([]byte, 512)
+	readBytes, _, err = l.ReadFrom(buf)
 	require.NoError(t, err)
-	bytes.Contains(buf, []byte(expectedMsg))
+	require.True(t, readBytes > 0)
+
+	require.True(t, bytes.Equal(buf[0:readBytes], []byte(expectedMsg)))
 }
 
 func TestDiscardSink(t *testing.T) {

--- a/tracing/config.go
+++ b/tracing/config.go
@@ -2,6 +2,7 @@ package tracing
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/sirupsen/logrus"
@@ -40,8 +41,17 @@ func Configure(tc *Config, log logrus.FieldLogger, svcName string) {
 			tracerOps = append(tracerOps, tracer.WithLogger(debugLogger{log.WithField("component", "opentracing")}))
 		}
 
+		var serviceTagSet bool
 		for k, v := range tc.Tags {
+			if strings.ToLower(k) == "service" {
+				serviceTagSet = true
+			}
+
 			tracerOps = append(tracerOps, tracer.WithGlobalTag(k, v))
+		}
+
+		if !serviceTagSet {
+			tracerOps = append(tracerOps, tracer.WithGlobalTag("service", svcName))
 		}
 
 		if tc.UseDatadog {


### PR DESCRIPTION
This adds an automatic global `service` tag to metrics and traces set to the service name. This provides automatic correlation of metrics and traces emitted by a service so they can be found in DD.

We only set this if the user hasn't already provided a global `service` tag.

