### PR TITLE
feature: allow specifying custom featureflag atributes

### DIFF
--- a/featureflag/config.go
+++ b/featureflag/config.go
@@ -18,5 +18,7 @@ type Config struct {
 	// Set when using the Launch Darkly Relay proxy
 	RelayHost string `json:"relay_host" yaml:"relay_host" mapstructure:"relay_host" split_words:"true"`
 
-	DefaultAttrs map[string]string `json:"default_attrs" yaml:"default_attrs"`
+	// DefaultUserAttrs are custom LaunchDarkly user attributes that are added to every
+	// feature flag check
+	DefaultUserAttrs map[string]string `json:"default_user_attrs" yaml:"default_user_attrs"`
 }

--- a/featureflag/config.go
+++ b/featureflag/config.go
@@ -17,4 +17,6 @@ type Config struct {
 
 	// Set when using the Launch Darkly Relay proxy
 	RelayHost string `json:"relay_host" yaml:"relay_host" mapstructure:"relay_host" split_words:"true"`
+
+	DefaultAttrs map[string]string `json:"default_attrs" yaml:"default_attrs"`
 }

--- a/featureflag/featureflag.go
+++ b/featureflag/featureflag.go
@@ -29,7 +29,7 @@ type ldClient struct {
 
 var _ Client = &ldClient{}
 
-func NewClient(cfg *Config, logger logrus.FieldLogger, defaultAttrs ...Attr) (Client, error) {
+func NewClient(cfg *Config, logger logrus.FieldLogger) (Client, error) {
 	config := ld.DefaultConfig
 
 	if !cfg.Enabled {
@@ -56,6 +56,11 @@ func NewClient(cfg *Config, logger logrus.FieldLogger, defaultAttrs ...Attr) (Cl
 	inner, err := ld.MakeCustomClient(cfg.Key, config, cfg.RequestTimeout.Duration)
 	if err != nil {
 		logger.WithError(err).Error("Unable to construct LD client")
+	}
+
+	var defaultAttrs []Attr
+	for k, v := range cfg.DefaultAttrs {
+		defaultAttrs = append(defaultAttrs, StringAttr(k, v))
 	}
 	return &ldClient{inner, logger, defaultAttrs}, err
 }

--- a/featureflag/featureflag.go
+++ b/featureflag/featureflag.go
@@ -59,7 +59,7 @@ func NewClient(cfg *Config, logger logrus.FieldLogger) (Client, error) {
 	}
 
 	var defaultAttrs []Attr
-	for k, v := range cfg.DefaultAttrs {
+	for k, v := range cfg.DefaultUserAttrs {
 		defaultAttrs = append(defaultAttrs, StringAttr(k, v))
 	}
 	return &ldClient{inner, logger, defaultAttrs}, err

--- a/featureflag/featureflag.go
+++ b/featureflag/featureflag.go
@@ -5,15 +5,16 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"gopkg.in/launchdarkly/go-sdk-common.v1/ldvalue"
 	ld "gopkg.in/launchdarkly/go-server-sdk.v4"
 	"gopkg.in/launchdarkly/go-server-sdk.v4/ldlog"
 )
 
 type Client interface {
-	Enabled(key, userID string) bool
+	Enabled(key, userID string, attrs ...Attr) bool
 	EnabledUser(key string, user ld.User) bool
 
-	Variation(key, defaultVal, userID string) string
+	Variation(key, defaultVal, userID string, attrs ...Attr) string
 	VariationUser(key string, defaultVal string, user ld.User) string
 
 	AllEnabledFlags(key string) []string
@@ -22,12 +23,13 @@ type Client interface {
 
 type ldClient struct {
 	*ld.LDClient
-	log logrus.FieldLogger
+	log          logrus.FieldLogger
+	defaultAttrs []Attr
 }
 
 var _ Client = &ldClient{}
 
-func NewClient(cfg *Config, logger logrus.FieldLogger) (Client, error) {
+func NewClient(cfg *Config, logger logrus.FieldLogger, defaultAttrs ...Attr) (Client, error) {
 	config := ld.DefaultConfig
 
 	if !cfg.Enabled {
@@ -55,11 +57,11 @@ func NewClient(cfg *Config, logger logrus.FieldLogger) (Client, error) {
 	if err != nil {
 		logger.WithError(err).Error("Unable to construct LD client")
 	}
-	return &ldClient{inner, logger}, err
+	return &ldClient{inner, logger, defaultAttrs}, err
 }
 
-func (c *ldClient) Enabled(key string, userID string) bool {
-	return c.EnabledUser(key, ld.NewUser(userID))
+func (c *ldClient) Enabled(key string, userID string, attrs ...Attr) bool {
+	return c.EnabledUser(key, c.userWithAttrs(userID, attrs))
 }
 
 func (c *ldClient) EnabledUser(key string, user ld.User) bool {
@@ -70,8 +72,8 @@ func (c *ldClient) EnabledUser(key string, user ld.User) bool {
 	return res
 }
 
-func (c *ldClient) Variation(key, defaultVal, userID string) string {
-	return c.VariationUser(key, defaultVal, ld.NewUser(userID))
+func (c *ldClient) Variation(key, defaultVal, userID string, attrs ...Attr) string {
+	return c.VariationUser(key, defaultVal, c.userWithAttrs(userID, attrs))
 }
 
 func (c *ldClient) VariationUser(key string, defaultVal string, user ld.User) string {
@@ -101,6 +103,26 @@ func (c *ldClient) AllEnabledFlagsUser(key string, user ld.User) []string {
 	}
 
 	return flags
+}
+
+func (c *ldClient) userWithAttrs(id string, attrs []Attr) ld.User {
+	b := ld.NewUserBuilder(id)
+	for _, attr := range c.defaultAttrs {
+		b.Custom(attr.Name, attr.Value)
+	}
+	for _, attr := range attrs {
+		b.Custom(attr.Name, attr.Value)
+	}
+	return b.Build()
+}
+
+type Attr struct {
+	Name  string
+	Value ldvalue.Value
+}
+
+func StringAttr(name, value string) Attr {
+	return Attr{Name: name, Value: ldvalue.String(value)}
 }
 
 func configureLogger(ldLogger *ldlog.Loggers, log logrus.FieldLogger) {

--- a/featureflag/global.go
+++ b/featureflag/global.go
@@ -25,8 +25,8 @@ func GetGlobalClient() Client {
 }
 
 // Init will initialize global client with a launch darkly client
-func Init(conf Config, log logrus.FieldLogger) error {
-	ldClient, err := NewClient(&conf, log)
+func Init(conf Config, log logrus.FieldLogger, defaultAttrs ...Attr) error {
+	ldClient, err := NewClient(&conf, log, defaultAttrs...)
 	if err != nil {
 		return err
 	}
@@ -34,10 +34,10 @@ func Init(conf Config, log logrus.FieldLogger) error {
 	return nil
 }
 
-func Enabled(key, userID string) bool {
-	return GetGlobalClient().Enabled(key, userID)
+func Enabled(key, userID string, attrs ...Attr) bool {
+	return GetGlobalClient().Enabled(key, userID, attrs...)
 }
 
-func Variation(key, defaultVal, userID string) string {
-	return GetGlobalClient().Variation(key, defaultVal, userID)
+func Variation(key, defaultVal, userID string, attrs ...Attr) string {
+	return GetGlobalClient().Variation(key, defaultVal, userID, attrs...)
 }

--- a/featureflag/global.go
+++ b/featureflag/global.go
@@ -25,8 +25,8 @@ func GetGlobalClient() Client {
 }
 
 // Init will initialize global client with a launch darkly client
-func Init(conf Config, log logrus.FieldLogger, defaultAttrs ...Attr) error {
-	ldClient, err := NewClient(&conf, log, defaultAttrs...)
+func Init(conf Config, log logrus.FieldLogger) error {
+	ldClient, err := NewClient(&conf, log)
 	if err != nil {
 		return err
 	}

--- a/featureflag/mock.go
+++ b/featureflag/mock.go
@@ -11,7 +11,7 @@ type MockClient struct {
 
 var _ Client = MockClient{}
 
-func (c MockClient) Enabled(key, userID string) bool {
+func (c MockClient) Enabled(key, userID string, _ ...Attr) bool {
 	return c.EnabledUser(key, ld.NewUser(userID))
 }
 
@@ -19,7 +19,7 @@ func (c MockClient) EnabledUser(key string, _ ld.User) bool {
 	return c.BoolVars[key]
 }
 
-func (c MockClient) Variation(key string, defaultVal string, userID string) string {
+func (c MockClient) Variation(key string, defaultVal string, userID string, _ ...Attr) string {
 	return c.VariationUser(key, defaultVal, ld.NewUser(userID))
 }
 


### PR DESCRIPTION
- make it possible to specify custom attributes when calling `featureflag.Enabled` etc, without manually creating the launch darkly user type.
- add config option to specify default attributes that get passed to every `featureflag.Enabled` call
