### PR TITLE
fix: properly handle urls in saferoundtripper

### DIFF
--- a/http/http.go
+++ b/http/http.go
@@ -51,9 +51,13 @@ type noLocalTransport struct {
 func (no noLocalTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	ctx, cancel := context.WithCancel(req.Context())
 
+	no.errlog.Error("CB: starting roundtrip")
+	no.errlog.Errorf("CB: allowed blocks - %v", no.allowedBlocks)
 	ctx = httptrace.WithClientTrace(ctx, &httptrace.ClientTrace{
 		GetConn: func(hostPort string) {
+			no.errlog.Errorf("CB: hostPort - %s", hostPort)
 			host, _, err := net.SplitHostPort(hostPort)
+			no.errlog.Errorf("CB: host - %s", host)
 			if err != nil {
 				cancel()
 				no.errlog.WithError(err).Error("Cancelled request due to error in address parsing")

--- a/http/http_test.go
+++ b/http/http_test.go
@@ -43,6 +43,10 @@ func TestSafeHTTPClient(t *testing.T) {
 
 	client := SafeHTTPClient(&http.Client{}, logrus.New())
 
+	// It allows accessing non-local addresses
+	_, err = client.Get("https://google.com")
+	require.Nil(t, err)
+
 	// It blocks the local IP.
 	_, err = client.Get(ts.URL)
 	require.NotNil(t, err)

--- a/http/http_test.go
+++ b/http/http_test.go
@@ -27,7 +27,10 @@ func TestIsPrivateIP(t *testing.T) {
 
 	for _, tt := range tests {
 		ip := net.ParseIP(tt.ip)
-		assert.Equal(t, tt.expected, isPrivateIP(ip))
+		if ip == nil {
+			require.Fail(t, "failed to parse IP")
+		}
+		assert.Equal(t, tt.expected, containsPrivateIP([]net.IP{ip}))
 	}
 }
 


### PR DESCRIPTION
Closes #266. We now attempt to resolve the hostname, and check all IP addresses returned against the allow list / deny list. 

Note: `net.LookupIP` works for both URLs and IP addresses. 


