### PR TITLE
Have fakeConsumer.close take the lock before closing the msg chan

### DIFF
--- a/kafka/kafkatest/utils.go
+++ b/kafka/kafkatest/utils.go
@@ -169,6 +169,8 @@ func (f *FakeKafkaConsumer) Resume(p []kafkalib.TopicPartition) error {
 }
 
 func (f *FakeKafkaConsumer) Close() error {
+	f.msgMu.Lock()
+	defer f.msgMu.Unlock()
 	close(f.commits)
 	return nil
 }


### PR DESCRIPTION
This sets the FakeKafkaConsumer#Close to grab the msg mutex lock and lock it before closing the channel. 

This prevents a race between a user closing the consumer and committing

Before we get this datarace:
```==================
WARNING: DATA RACE
Write at 0x00c0001a4310 by goroutine 30:
  runtime.closechan()
      /usr/local/go/src/runtime/chan.go:355 +0x0
  github.com/netlify/netlify-commons/kafka/kafkatest.(*FakeKafkaConsumer).Close()
      /home/shane/code/netlify/clickhouse-forwarder/vendor/github.com/netlify/netlify-commons/kafka/kafka
test/utils.go:172 +0x44
  github.com/netlify/clickhouse-forwarder/forwarder.(*Forwarder).Stop()
      /home/shane/code/netlify/clickhouse-forwarder/forwarder/forwarder.go:134 +0x113
  github.com/netlify/clickhouse-forwarder/forwarder.TestStart·dwrap·7()
      /home/shane/code/netlify/clickhouse-forwarder/forwarder/forwarder_test.go:46 +0x39
  github.com/netlify/clickhouse-forwarder/forwarder.TestStart()
      /home/shane/code/netlify/clickhouse-forwarder/forwarder/forwarder_test.go:118 +0xbee
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1259 +0x22f
  testing.(*T).Run·dwrap·21()
      /usr/local/go/src/testing/testing.go:1306 +0x47

Previous read at 0x00c0001a4310 by goroutine 32:
  runtime.chansend()
      /usr/local/go/src/runtime/chan.go:158 +0x0
  github.com/netlify/netlify-commons/kafka/kafkatest.(*FakeKafkaConsumer).CommitMessage()
      /home/shane/code/netlify/clickhouse-forwarder/vendor/github.com/netlify/netlify-commons/kafka/kafka
test/utils.go:117 +0x24d
  github.com/netlify/clickhouse-forwarder/forwarder.(*Forwarder).Start()
      /home/shane/code/netlify/clickhouse-forwarder/forwarder/forwarder.go:94 +0x622
  github.com/netlify/clickhouse-forwarder/forwarder.TestStart·dwrap·6()
      /home/shane/code/netlify/clickhouse-forwarder/forwarder/forwarder_test.go:45 +0x39

...
...
==================
```

After we don't get a datarace, but if the user of the test utils package calls commit after close they'll see a panic akin to:
```
panic: send on closed channel [recovered]
        panic: send on closed channel
```

BREAKING CHANGES:
n/a