### PR TITLE
fix: Link librdkafka dynamically for M1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,15 +2,21 @@
 
 export GO111MODULE=on
 
+arch = $(shell uname -p)
+gotags=
+ifeq ($(arch),arm)
+gotags = -tags dynamic
+endif
+
 build:
-	go build ./...
+	go build $(gotags) ./...
 
 deps:
 	go mod verify
 	go mod tidy
 
 test:
-	go test -race ./...
+	go test -race $(gotags) ./...
 
 integration-test:
 	docker-compose -f Dockercompose.test.yml up --build --abort-on-container-exit --always-recreate-deps

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Mostly this deals with configuring logging, messaging (rabbit && nats), and load
 ## Testing
 ### Prerequisites
 
-If running on Applie silicon, the librdkafka library will need to be linked dynamically. We may want to keep an eye on [issues](https://github.com/confluentinc/confluent-kafka-go/issues/696) in the confluent-kakfa-go repository for alternative approaches that we could use in the future.
+If running on Apple silicon, the `librdkafka` library will need to be linked dynamically. We may want to keep an eye on [issues](https://github.com/confluentinc/confluent-kafka-go/issues/696) in the `confluent-kakfa-go` repository for alternative approaches that we could use in the future.
 
 ```
 brew install openssl

--- a/README.md
+++ b/README.md
@@ -2,8 +2,24 @@
 
 [![](https://godoc.org/github.com/netlify/netlify-commons?status.svg)](https://godoc.org/github.com/netlify/netlify-commons)
 
-This is a core library that will add common features for our services. 
+This is a core library that will add common features for our services.
 
-> The ones that have their own right now will be migrated as needed 
+> The ones that have their own right now will be migrated as needed
 
-Mostly this deals with configuring logging, messaging (rabbit && nats), and loading configuration. 
+Mostly this deals with configuring logging, messaging (rabbit && nats), and loading configuration.
+
+## Testing
+### Prerequisites
+
+If running on Applie silicon, the librdkafka library will need to be linked dynamically. We may want to keep an eye on [issues](https://github.com/confluentinc/confluent-kafka-go/issues/696) in the confluent-kakfa-go repository for alternative approaches that we could use in the future.
+
+```
+brew install openssl
+brew install librdkafka
+brew install pkg-config
+```
+
+And add `PKG_CONFIG_PATH` to your `~/.bashrc` or `~/.zshrc` (as instructed by `brew info openssl`)
+```
+export PKG_CONFIG_PATH="/opt/homebrew/opt/openssl@3/lib/pkgconfig"
+```


### PR DESCRIPTION
**Summary**
The librdkafka library needs to be linked dynamically for M1. See [this comment](https://github.com/confluentinc/confluent-kafka-go/issues/591#issuecomment-951113445) on a github issue.