### PR TITLE
Report gauges once per interval

### DIFF
--- a/metriks/gauge.go
+++ b/metriks/gauge.go
@@ -15,9 +15,7 @@ const (
 )
 
 // PersistentGauge will report on an interval the value to the metrics collector.
-// Every call to the methods to modify the value immediately report, but if we
-// don't have a change inside the window (default 10s) after the last report
-// we will report the current value.
+//
 type PersistentGauge struct {
 	name  string
 	value int32
@@ -31,24 +29,17 @@ type PersistentGauge struct {
 
 // Set will replace the value with a new one, it returns the old value
 func (g *PersistentGauge) Set(value int32) int32 {
-	v := atomic.SwapInt32(&g.value, value)
-	g.report(value)
-
-	return v
+	return atomic.SwapInt32(&g.value, value)
 }
 
 // Inc will +1 to the current value and return the new value
 func (g *PersistentGauge) Inc() int32 {
-	v := atomic.AddInt32(&g.value, 1)
-	g.report(v)
-	return v
+	return atomic.AddInt32(&g.value, 1)
 }
 
 // Dec will -1 to the current value and return the new value
 func (g *PersistentGauge) Dec() int32 {
-	v := atomic.AddInt32(&g.value, -1)
-	g.report(v)
-	return v
+	return atomic.AddInt32(&g.value, -1)
 }
 
 func (g *PersistentGauge) report(v int32) {

--- a/metriks/gauge_test.go
+++ b/metriks/gauge_test.go
@@ -23,15 +23,11 @@ func TestPersistentGauge(t *testing.T) {
 	assert.EqualValues(t, 0, g.Set(10))
 
 	expectedValues := []string{
-		// these values should be reported everytime we make a call
-		"test.some_gauge.b:1.000000|g",
-		"test.some_gauge.b:0.000000|g",
-		"test.some_gauge.b:10.000000|g",
 		// this value should be reported after an interval
 		"test.some_gauge.b:10.000000|g",
 	}
 
-	for i := 0; i < 4; i++ {
+	for i := 0; i < len(expectedValues); i++ {
 		select {
 		case msg := <-res:
 			assert.Equal(t, expectedValues[i], msg)


### PR DESCRIPTION
Gauges report a snapshot value once per interval, so we don't need to report on every change. There shouldn't be a difference between reporting N times per interval and selecting one vs. simply reporting once. This should reduce overhead of reporting for gauges with high-frequency change rates.
