### PR TITLE
chore: Test on Go 1.17

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.15.x", "1.16.x"]
+        go: ["1.15.x", "1.16.x", "1.17.x"]
     steps:
       - uses: actions/checkout@master
       - uses: actions/setup-go@v1


### PR DESCRIPTION
Since many services are already using 1.17, this is important.