### PR TITLE
chore: Fix renovate schedule setting

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,7 +8,7 @@
     {
       "matchDatasources": ["go"],
       "matchPackageNames": ["gopkg.in/yaml.v3", "golang.org/x/net"],
-      "schedule": "before 3am on the first tuesday of the month"
+      "schedule": "before 3am on the first day of the month"
     }
   ]
 }


### PR DESCRIPTION
The schedule for annoying dependencies was invalid.
The one used now is directly copied from their manual.