### PR TITLE
chore: Improve release please details

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,3 +12,4 @@ jobs:
         with:
           release-type: go
           package-name: netlify-commons
+          bump-minor-pre-major: true

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,3 +13,4 @@ jobs:
           release-type: go
           package-name: netlify-commons
           bump-minor-pre-major: true
+          token: ${{ secrets.PKG_RELEASE_TOKEN }}


### PR DESCRIPTION
- Avoid cutting a 1.0.0 with a breaking change
  - this matters for Go, because for any further breaking change the import path would change and i don't think that's useful
- Use a different github token
  - When using the actions token, no actions will be triggered when release-please makes a PR which leaves the required checks waiting