### PR TITLE
chore: Aquire token for release please on the fly

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,9 +8,15 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      - uses: navikt/github-app-token-generator@2d70c12368d1958155af4d283f9f21c9a2a8cb98
+        id: get-token
+        with:
+          private-key: ${{ secrets.TOKENS_PRIVATE_KEY }}
+          app-id: ${{ secrets.TOKENS_APP_ID }}
+
       - uses: GoogleCloudPlatform/release-please-action@v3
         with:
           release-type: go
           package-name: netlify-commons
           bump-minor-pre-major: true
-          token: ${{ secrets.PKG_RELEASE_TOKEN }}
+          token: ${{ steps.get-token.outputs.token }}


### PR DESCRIPTION
Release-please on main is broken right now, since the Github API token i tried to use in https://github.com/netlify/netlify-commons/pull/301 should not be used anymore.

This new method acquires a token from a github app instead which is much nicer.