### PR TITLE
chore: update how we get request IDs

### DIFF
--- a/router/router_test.go
+++ b/router/router_test.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/netlify/netlify-commons/testutil"
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/mocktracer"
 	"github.com/sirupsen/logrus"
@@ -83,7 +84,8 @@ func TestTracing(t *testing.T) {
 		return nil
 	}
 
-	r := New(logrus.WithField("test", t.Name()), OptEnableTracing("some-service"))
+	tl, logHook := testutil.TestLogger(t)
+	r := New(tl, OptEnableTracing("some-service"))
 
 	r.Method(http.MethodPatch, "/patch", noop)
 	r.Delete("/abc/{def}", noop)
@@ -110,6 +112,7 @@ func TestTracing(t *testing.T) {
 	for name, scene := range scenes {
 		t.Run(name, func(t *testing.T) {
 			mt.Reset()
+			logHook.Reset()
 
 			rec := httptest.NewRecorder()
 			r.ServeHTTP(rec, httptest.NewRequest(scene.method, scene.path, nil))
@@ -121,6 +124,8 @@ func TestTracing(t *testing.T) {
 				assert.Equal(t, scene.resourceName, spans[0].Tag(ext.ResourceName))
 				assert.Equal(t, strconv.Itoa(http.StatusOK), spans[0].Tag(ext.HTTPCode))
 			}
+			// should be a starting and finished request for each request
+			assert.Len(t, logHook.AllEntries(), 2)
 		})
 	}
 }

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/netlify/netlify-commons/testutil"
+	"github.com/netlify/netlify-commons/tracing"
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/mocktracer"
 	"github.com/sirupsen/logrus"
@@ -80,6 +81,7 @@ func TestTracing(t *testing.T) {
 	}()
 
 	noop := func(w http.ResponseWriter, r *http.Request) error {
+		assert.NotNil(t, tracing.GetTracer(r))
 		w.WriteHeader(http.StatusOK)
 		return nil
 	}

--- a/tracing/context.go
+++ b/tracing/context.go
@@ -3,6 +3,8 @@ package tracing
 import (
 	"context"
 	"net/http"
+
+	uuid "github.com/satori/go.uuid"
 )
 
 type contextKey string
@@ -33,7 +35,10 @@ func GetRequestID(r *http.Request) string {
 	if id := GetRequestIDFromContext(r.Context()); id != "" {
 		return id
 	}
-	return r.Header.Get(HeaderRequestUUID)
+	if rid := r.Header.Get(HeaderRequestUUID); rid != "" {
+		return rid
+	}
+	return uuid.NewV4().String()
 }
 
 func GetRequestIDFromContext(ctx context.Context) string {

--- a/tracing/logging.go
+++ b/tracing/logging.go
@@ -8,17 +8,14 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const (
-	logKey = contextKey("nf-log-key")
-)
-
-func requestLogger(r *http.Request, log logrus.FieldLogger) (logrus.FieldLogger, string) {
+func RequestLogger(r *http.Request, log logrus.FieldLogger) (logrus.FieldLogger, string) {
 	if r.Header.Get(HeaderNFDebugLogging) != "" {
 		logger := logrus.New()
 		logger.SetLevel(logrus.DebugLevel)
 
 		if entry, ok := log.(*logrus.Entry); ok {
 			log = logger.WithFields(entry.Data)
+			logger.Hooks = entry.Logger.Hooks
 		}
 	}
 

--- a/tracing/req_tracer.go
+++ b/tracing/req_tracer.go
@@ -27,7 +27,7 @@ type RequestTracer struct {
 
 func NewTracer(w http.ResponseWriter, r *http.Request, log logrus.FieldLogger, service, resource string) (http.ResponseWriter, *http.Request, *RequestTracer) {
 	var reqID string
-	log, reqID = requestLogger(r, log)
+	log, reqID = RequestLogger(r, log)
 
 	r, span := WrapWithSpan(r, reqID, service, resource)
 	trackWriter := &trackingWriter{


### PR DESCRIPTION
I was debugging some other service I'm starting and noticed that I wanted to validate that (1) the tracer is present and (2) that we're doing the start/finished lines. That made me realize that we're not copying the hooks over. So I fixed that. 

Then I wanted to improve a few things:
- make the tracer package always return a request ID so we can use that to generate missing one
- have a reliable way to get a per-request logger. So export that function. 