### PR TITLE
DNMY - figure out how to get reporting for endpoints with the path

### DIFF
--- a/router/middleware.go
+++ b/router/middleware.go
@@ -147,6 +147,12 @@ func BugSnag() Middleware {
 	})
 }
 
+type tracingMiddleware struct {
+	patterns map[http.Handler]string
+	log      logrus.FieldLogger
+	svcName  string
+}
+
 func TrackAllRequests(log logrus.FieldLogger, service string) Middleware {
 	return MiddlewareFunc(func(w http.ResponseWriter, r *http.Request, next http.Handler) {
 		// This is to maintain some legacy span work. It will cause the APM requests

--- a/router/options.go
+++ b/router/options.go
@@ -1,37 +1,81 @@
 package router
 
-type Option func(r *chiWrapper)
+import (
+	"net/http"
 
-func OptEnableCORS(r *chiWrapper) {
-	r.enableCORS = true
+	"github.com/netlify/netlify-commons/tracing"
+)
+
+type Option struct {
+	f func(r *chiWrapper)
+}
+
+func OptEnableCORS() Option {
+	return Option{
+		f: func(r *chiWrapper) {
+			r.enableCORS = true
+		},
+	}
 }
 
 func OptHealthCheck(path string, checker APIHandler) Option {
-	return func(r *chiWrapper) {
-		r.healthEndpoint = path
-		r.healthHandler = checker
+	return Option{
+		f: func(r *chiWrapper) {
+			r.healthEndpoint = path
+			r.healthHandler = checker
+		},
 	}
 }
 
 func OptVersionHeader(svcName, version string) Option {
-	return func(r *chiWrapper) {
-		if version == "" {
-			version = "unknown"
-		}
-		r.version = version
-		r.svcName = svcName
+	return Option{
+		f: func(r *chiWrapper) {
+			if version == "" {
+				version = "unknown"
+			}
+			r.version = version
+			r.svcName = svcName
+		},
 	}
 }
 
 func OptEnableTracing(svcName string) Option {
-	return func(r *chiWrapper) {
-		r.svcName = svcName
-		r.enableTracing = true
+	return Option{
+		f: func(r *chiWrapper) {
+			r.svcName = svcName
+			r.enableTracing = true
+			r.chi.NotFound(func(w http.ResponseWriter, req *http.Request) {
+				tracing.TrackRequest(
+					w,
+					req,
+					r.rootLogger,
+					svcName,
+					req.Method,
+					http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						w.WriteHeader(http.StatusNotFound)
+					}),
+				)
+			})
+			r.chi.MethodNotAllowed(func(w http.ResponseWriter, req *http.Request) {
+				tracing.TrackRequest(
+					w,
+					req,
+					r.rootLogger,
+					svcName,
+					req.Method,
+					http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						w.WriteHeader(http.StatusNotFound)
+					}),
+				)
+			})
+		},
 	}
 }
 
 func OptRecoverer() Option {
-	return func(r *chiWrapper) {
-		r.enableRecover = true
+	return Option{
+		f: func(r *chiWrapper) {
+			r.enableRecover = true
+		},
 	}
 }


### PR DESCRIPTION
ok this is not going to be merged as is, more as a discussion. 

I was working on some other service and realized I wasn't logging 401s and 404s. So I traced that back to the router. We never get a call for a 404, duuuuh I went. So I found that we have handlers for not found and method not allowed. All is good in the world.

BUT

No. So I was looking and if your middleware stack rejects the call _before_ we get to the actual handler, so think CORS and auth, we won't log/count either. The problem is that we only wrap when we get to the very end. Then naturally we need to tweak the middleware stack to be _first_ and then let the other handlers reject as makes sense. Sweet. Easy. 

BUT 

We try to encode the 'pattern' in the handler's APM for better visibility. This way we can get top level paths in datadog for `GET.my.special.path` and not for every unique path at the top. This is where we are now. The problem is that (1) chi doesn't know the path until _after_ it has invoked the handler. That is _after_ we could block the call. (2) we can't really 'register' any object I can think of or put it in the context to let us know that until after the route is defined. This means I can't easily see how often `GET.my.authenticated.endpoint` is getting hit with a 401. Yes we can log that now (yay) but spans won't show that. 

What I'm thinking of doing is actually maybe splitting the problem. Leave the code ~as is (just the err handlers). But also start a parent span we report if we don't report another? IDK I'm pretty stumped and don't think that will actually work. Or maybe just start a new child span and put the pattern there? 