### PR TITLE
feat: HTTPError.WithFields

### DIFF
--- a/router/errors.go
+++ b/router/errors.go
@@ -13,13 +13,13 @@ import (
 
 // HTTPError is an error with a message and an HTTP status code.
 type HTTPError struct {
-	Code            int             `json:"code"`
-	Message         string          `json:"msg"`
-	JSON            interface{}     `json:"json,omitempty"`
-	InternalError   error           `json:"-"`
-	InternalMessage string          `json:"-"`
-	ErrorID         string          `json:"error_id,omitempty"`
-	Fields          []logrus.Fields `json:"-"`
+	Code            int           `json:"code"`
+	Message         string        `json:"msg"`
+	JSON            interface{}   `json:"json,omitempty"`
+	InternalError   error         `json:"-"`
+	InternalMessage string        `json:"-"`
+	ErrorID         string        `json:"error_id,omitempty"`
+	Fields          logrus.Fields `json:"-"`
 }
 
 // BadRequestError creates a 400 HTTP error
@@ -83,21 +83,23 @@ func (e *HTTPError) WithInternalMessage(fmtString string, args ...interface{}) *
 
 // WithFields will add fields to an error message
 func (e *HTTPError) WithFields(fields logrus.Fields) *HTTPError {
-	e.Fields = append(e.Fields, fields)
+	for key, value := range fields {
+		e.Fields[key] = value
+	}
 	return e
 }
 
 // WithFields will add fields to an error message
 func (e *HTTPError) WithField(key string, value interface{}) *HTTPError {
-	return e.WithFields(logrus.Fields{
-		key: value,
-	})
+	e.Fields[key] = value
+	return e
 }
 
 func httpError(code int, fmtString string, args ...interface{}) *HTTPError {
 	return &HTTPError{
 		Code:    code,
 		Message: fmt.Sprintf(fmtString, args...),
+		Fields:  make(logrus.Fields),
 	}
 }
 
@@ -117,9 +119,7 @@ func HandleError(err error, w http.ResponseWriter, r *http.Request) {
 
 	switch e := err.(type) {
 	case *HTTPError:
-		for _, fields := range e.Fields {
-			log = log.WithFields(fields)
-		}
+		log = log.WithFields(e.Fields)
 
 		e.ErrorID = errorID
 		if e.Code >= http.StatusInternalServerError {

--- a/router/errors.go
+++ b/router/errors.go
@@ -13,13 +13,13 @@ import (
 
 // HTTPError is an error with a message and an HTTP status code.
 type HTTPError struct {
-	Code            int         `json:"code"`
-	Message         string      `json:"msg"`
-	JSON            interface{} `json:"json,omitempty"`
-	InternalError   error       `json:"-"`
-	InternalMessage string      `json:"-"`
-	ErrorID         string      `json:"error_id,omitempty"`
-	Fields          []logrus.Fields
+	Code            int             `json:"code"`
+	Message         string          `json:"msg"`
+	JSON            interface{}     `json:"json,omitempty"`
+	InternalError   error           `json:"-"`
+	InternalMessage string          `json:"-"`
+	ErrorID         string          `json:"error_id,omitempty"`
+	Fields          []logrus.Fields `json:"-"`
 }
 
 // BadRequestError creates a 400 HTTP error

--- a/router/errors_test.go
+++ b/router/errors_test.go
@@ -122,6 +122,36 @@ func TestHandleError_HTTPError(t *testing.T) {
 	assert.Equal(t, "internal server error: "+httpErr.InternalMessage, loggerOutput.AllEntries()[0].Message)
 }
 
+func TestHandleError_HttpErrorWithFields(t *testing.T) {
+	logger, loggerOutput := test.NewNullLogger()
+	recorder := httptest.NewRecorder()
+	w, r, _ := tracing.NewTracer(
+		recorder,
+		httptest.NewRequest(http.MethodGet, "/", nil),
+		logger,
+		"test",
+		"test",
+	)
+
+	httpErr := httpError(http.StatusInternalServerError, http.StatusText(http.StatusInternalServerError))
+
+	httpErr.WithFields(map[string]interface{}{
+		"a": "1",
+		"b": "2",
+	})
+
+	httpErr.WithField("c", "3")
+	httpErr.WithField("a", "0")
+
+	HandleError(httpErr, w, r)
+
+	require.Len(t, loggerOutput.AllEntries(), 1)
+	entry := loggerOutput.LastEntry()
+	assert.Equal(t, entry.Data["a"], "0")
+	assert.Equal(t, entry.Data["b"], "2")
+	assert.Equal(t, entry.Data["c"], "3")
+}
+
 func TestHandleError_NoLogForNormalErrors(t *testing.T) {
 	logger, loggerOutput := test.NewNullLogger()
 	recorder := httptest.NewRecorder()


### PR DESCRIPTION
This PR adds `.WithFields` and `.WithField` methods to `HTTPError`, which act as a facade to Logrus' methods.
They allow to easily add custom log fields to error messages.

# how this helps

At the moment, when you want to add additional information to an HTTP error, you need to print two log lines:

```go
logger.WithError(err).WithField("body", string(body)).Error("error unmarshaling events")
return router.BadRequestError("error parsing body: %s", err.Error())
```

With this PR, we can trim it down to one:

```go
return router.BadRequestError("error parsing body: %s", err.Error()).WithInternalError(err).WithField("body", string(body))
```


(taken from https://github.com/netlify/ingesteer/pull/18#discussion_r813652764)

<!-- We follow the Conventional Commits guide: https://www.conventionalcommits.org/en/v1.0.0/#summary -->
