### PR TITLE
fix: prevent race condition in Stop method on gauge

### DIFF
--- a/metriks/gauge_test.go
+++ b/metriks/gauge_test.go
@@ -37,6 +37,13 @@ func TestPersistentGauge(t *testing.T) {
 	}
 }
 
+func TestPersistentGaugeRace(t *testing.T) {
+	for n := 0; n < 10; n++ {
+		g := NewPersistentGaugeWithDuration("some_gauge", time.Second, L("a", "b"))
+		g.Stop()
+	}
+}
+
 func TestScheduledGauge(t *testing.T) {
 	var callCount int32
 	cb := func() int32 {


### PR DESCRIPTION
This was causing some flakiness in the test suite of another service. Because `wg.Add` is called in a separate goroutine there's no guarantee that it gets called before users call `Stop` on the gauge.
