### PR TITLE
feat: allow disabling trace logging, while keeping Datadog tracing enabled

### DIFF
--- a/router/errors_test.go
+++ b/router/errors_test.go
@@ -26,6 +26,7 @@ func TestHandleError_ErrorIsNil(t *testing.T) {
 		logger,
 		"test",
 		"test",
+		true,
 	)
 
 	HandleError(nil, w, r)
@@ -42,6 +43,7 @@ func TestHandleError_ErrorIsNilPointerToTypeHTTPError(t *testing.T) {
 		logger,
 		"test",
 		"test",
+		true,
 	)
 
 	h := func(_ http.ResponseWriter, _ *http.Request) *HTTPError {
@@ -62,6 +64,7 @@ func TestHandleError_ErrorIsNilInterface(t *testing.T) {
 		logger,
 		"test",
 		"test",
+		true,
 	)
 
 	h := func(_ http.ResponseWriter, _ *http.Request) error {
@@ -82,6 +85,7 @@ func TestHandleError_StandardError(t *testing.T) {
 		logger,
 		"test",
 		"test",
+		true,
 	)
 
 	HandleError(errors.New("random error"), w, r)
@@ -100,6 +104,7 @@ func TestHandleError_HTTPError(t *testing.T) {
 		logger,
 		"test",
 		"test",
+		true,
 	)
 
 	httpErr := &HTTPError{
@@ -131,6 +136,7 @@ func TestHandleError_HttpErrorWithFields(t *testing.T) {
 		logger,
 		"test",
 		"test",
+		true,
 	)
 
 	httpErr := httpError(http.StatusInternalServerError, http.StatusText(http.StatusInternalServerError))
@@ -161,6 +167,7 @@ func TestHandleError_NoLogForNormalErrors(t *testing.T) {
 		logger,
 		"test",
 		"test",
+		true,
 	)
 
 	httpErr := BadRequestError("not found yo.")
@@ -194,6 +201,7 @@ func TestHandleError_ErrorIsNilPointerToTypeOtherError(t *testing.T) {
 		logger,
 		"test",
 		"test",
+		true,
 	)
 
 	var oe *OtherError

--- a/router/middleware.go
+++ b/router/middleware.go
@@ -151,6 +151,6 @@ func TrackAllRequests(log logrus.FieldLogger, service string) Middleware {
 	return MiddlewareFunc(func(w http.ResponseWriter, r *http.Request, next http.Handler) {
 		// This is to maintain some legacy span work. It will cause the APM requests
 		// to show up as the method on the top level
-		tracing.TrackRequest(w, r, log, service, r.Method, next)
+		tracing.TrackRequest(w, r, log, service, r.Method, true, next)
 	})
 }

--- a/router/middleware_test.go
+++ b/router/middleware_test.go
@@ -135,6 +135,7 @@ func TestRecoveryInternalTracer(t *testing.T) {
 		logger,
 		t.Name(),
 		"some_resource",
+		true,
 	)
 	mw := Recoverer(logrus.New())
 	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/router/options.go
+++ b/router/options.go
@@ -27,6 +27,13 @@ func OptEnableTracing(svcName string) Option {
 	return func(r *chiWrapper) {
 		r.svcName = svcName
 		r.enableTracing = true
+		r.enableTraceLogging = true
+	}
+}
+
+func OptDisableTraceLogging() Option {
+	return func(r *chiWrapper) {
+		r.enableTraceLogging = false
 	}
 }
 

--- a/router/router.go
+++ b/router/router.go
@@ -23,9 +23,10 @@ type chiWrapper struct {
 	healthEndpoint string
 	healthHandler  APIHandler
 
-	enableTracing bool
-	enableCORS    bool
-	enableRecover bool
+	enableTracing      bool
+	enableTraceLogging bool
+	enableCORS         bool
+	enableRecover      bool
 }
 
 // Router wraps the chi router to make it slightly more accessible
@@ -145,7 +146,7 @@ func (r *chiWrapper) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 func (r *chiWrapper) Mount(pattern string, h http.Handler) {
 	if r.enableTracing {
 		h = http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-			tracing.TrackRequest(w, req, r.rootLogger, r.svcName, pattern, h)
+			tracing.TrackRequest(w, req, r.rootLogger, r.svcName, pattern, r.enableTraceLogging, h)
 		})
 	}
 	r.chi.Mount(pattern, h)
@@ -179,7 +180,7 @@ func (r *chiWrapper) traceRequest(method, pattern string, fn APIHandler) http.Ha
 		}
 
 		return func(w http.ResponseWriter, req *http.Request) {
-			tracing.TrackRequest(w, req, r.rootLogger, r.svcName, resourceName, f)
+			tracing.TrackRequest(w, req, r.rootLogger, r.svcName, resourceName, r.enableTraceLogging, f)
 		}
 	}
 	return f

--- a/server/server.go
+++ b/server/server.go
@@ -32,7 +32,8 @@ type Server struct {
 }
 
 type RouterConfig struct {
-	DisableTracing bool
+	DisableTracing      bool
+	DisableTraceLogging bool
 }
 
 type Config struct {
@@ -194,6 +195,10 @@ func buildRouter(log logrus.FieldLogger, api APIDefinition, config Config) route
 
 	if !config.Router.DisableTracing {
 		opts = append(opts, router.OptEnableTracing(api.Info().Name))
+	}
+
+	if config.Router.DisableTraceLogging {
+		opts = append(opts, router.OptDisableTraceLogging())
 	}
 
 	r := router.New(

--- a/tracing/req_tracer_test.go
+++ b/tracing/req_tracer_test.go
@@ -20,7 +20,7 @@ func TestTracerLogging(t *testing.T) {
 
 	log, hook := logtest.NewNullLogger()
 
-	_, r, rt := NewTracer(rec, req, log, t.Name(), "some_resource")
+	_, r, rt := NewTracer(rec, req, log, t.Name(), "some_resource", true)
 
 	rt.Start()
 	e := hook.LastEntry()
@@ -66,6 +66,19 @@ func TestTracerLogging(t *testing.T) {
 	assert.Equal(t, "line", e.Data["final"])
 }
 
+func TestTracerLoggingIfDisabled(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "http://whatever.com/something", nil)
+
+	log, hook := logtest.NewNullLogger()
+
+	_, _, rt := NewTracer(rec, req, log, t.Name(), "some_resource", false)
+
+	rt.Start()
+	rt.Finish()
+	assert.Len(t, hook.Entries, 0)
+}
+
 func TestTracerSpans(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "http://whatever.com/something", nil)
@@ -74,7 +87,7 @@ func TestTracerSpans(t *testing.T) {
 
 	mt := mocktracer.New()
 	opentracing.SetGlobalTracer(mt)
-	_, _, rt := NewTracer(rec, req, log, t.Name(), "some_resource")
+	_, _, rt := NewTracer(rec, req, log, t.Name(), "some_resource", true)
 	rt.Start()
 	rt.WriteHeader(http.StatusOK)
 	rt.Finish()

--- a/tracing/tracer.go
+++ b/tracing/tracer.go
@@ -11,8 +11,8 @@ import (
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/opentracer"
 )
 
-func TrackRequest(w http.ResponseWriter, r *http.Request, log logrus.FieldLogger, service, resource string, next http.Handler) {
-	w, r, rt := NewTracer(w, r, log, service, resource, true)
+func TrackRequest(w http.ResponseWriter, r *http.Request, log logrus.FieldLogger, service, resource string, enableTraceLogging bool, next http.Handler) {
+	w, r, rt := NewTracer(w, r, log, service, resource, enableTraceLogging)
 	rt.Start()
 	next.ServeHTTP(w, r)
 	rt.Finish()

--- a/tracing/tracer.go
+++ b/tracing/tracer.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TrackRequest(w http.ResponseWriter, r *http.Request, log logrus.FieldLogger, service, resource string, next http.Handler) {
-	w, r, rt := NewTracer(w, r, log, service, resource)
+	w, r, rt := NewTracer(w, r, log, service, resource, true)
 	rt.Start()
 	next.ServeHTTP(w, r)
 	rt.Finish()


### PR DESCRIPTION
This PR extends the `DisableTracing` config property added in https://github.com/netlify/netlify-commons/pull/338 to add a more fine-granular `DisableTraceLogging` option.

This allows services like Ingesteer, which have lots of requests but don't really need all of them logged, to only enable Datadog tracing, but not log information about every single request to Humio.

Works towards https://github.com/netlify/ingesteer/issues/169.