### PR TITLE
chore: remove pr auto labeler action

### DIFF
--- a/.github/workflows/pr-conventions.yml
+++ b/.github/workflows/pr-conventions.yml
@@ -7,26 +7,6 @@ on:
       - synchronize
 
 jobs:
-  label-pr:
-    name: Auto-label PR
-    runs-on: ubuntu-latest
-    steps:
-      - uses: netlify/pr-labeler-action@v1.0.0
-        if: startsWith(github.event.pull_request.title, 'fix')
-        with:
-          token: "${{ secrets.GITHUB_TOKEN }}"
-          label: "type: bug"
-      - uses: netlify/pr-labeler-action@v1.0.0
-        if: startsWith(github.event.pull_request.title, 'chore')
-        with:
-          token: "${{ secrets.GITHUB_TOKEN }}"
-          label: "type: chore"
-      - uses: netlify/pr-labeler-action@v1.0.0
-        if: startsWith(github.event.pull_request.title, 'feat')
-        with:
-          token: "${{ secrets.GITHUB_TOKEN }}"
-          label: "type: feature"
-
   lint:
     name: Lint PR title
     runs-on: ubuntu-latest


### PR DESCRIPTION
We are no longer required to label PRs with the type:* label. Removing the automation that supported this.