### PR TITLE
fix: add json annotations for ntoml.Plugin

### DIFF
--- a/ntoml/netlify_toml.go
+++ b/ntoml/netlify_toml.go
@@ -40,8 +40,8 @@ type BuildConfig struct {
 }
 
 type Plugin struct {
-	Package       string `toml:"package"`
-	PinnedVersion string `toml:"pinned_version,omitempty"`
+	Package       string `toml:"package" json:"package"`
+	PinnedVersion string `toml:"pinned_version,omitempty" json:"pinned_version,omitempty"`
 }
 
 type DeployContext struct {


### PR DESCRIPTION
There's still one place in `buildbot` where the `ntoml.Plugin` is serialized to `json`:

https://github.com/netlify/buildbot/blob/main/messages/cmd_data.go#L41